### PR TITLE
Remove typos and duplicates in CPP/US

### DIFF
--- a/packages/cpp/cpp.txt
+++ b/packages/cpp/cpp.txt
@@ -73843,8 +73843,6 @@ supdup
 supe
 supedot
 super
-superceded
-superceeded
 superclass
 superclasses
 superfluous

--- a/packages/cpp/cpp.txt
+++ b/packages/cpp/cpp.txt
@@ -32411,7 +32411,6 @@ indent
 Indentation
 indented
 Indention
-independant
 independence
 independent
 independently

--- a/packages/cpp/cpp.txt
+++ b/packages/cpp/cpp.txt
@@ -73774,14 +73774,10 @@ SucceedsEqual
 SucceedsSlantEqual
 SucceedsTilde
 succeq
-succesful
-succesfull
-succesfully
 success
 successes
 successful
 SuccessfulExit
-successfull
 successfully
 succession
 successive

--- a/packages/cpp/cpp.txt
+++ b/packages/cpp/cpp.txt
@@ -26491,7 +26491,6 @@ gathers
 gather_propsets
 Gaudet
 GAUGE
-gaurds
 Gaussian
 gave
 Gay

--- a/packages/cpp/cpp.txt
+++ b/packages/cpp/cpp.txt
@@ -63085,7 +63085,6 @@ recently
 reception
 receptions
 rechdr
-reciept
 recip
 recipe
 recipeCnt

--- a/packages/cpp/cpp.txt
+++ b/packages/cpp/cpp.txt
@@ -32365,7 +32365,6 @@ INCL_DOSERRORS
 incode
 incoherent
 incoming
-incomming
 incompatibilities
 incompatible
 incompatibly

--- a/packages/cpp/cpp.txt
+++ b/packages/cpp/cpp.txt
@@ -5385,7 +5385,6 @@ ap_xml_parse_input
 ap__a
 ap__b
 Aqs
-aquistion
 AQ_BUFSZ
 aq_delay
 AQ_HIWATER

--- a/packages/cpp/cpp.txt
+++ b/packages/cpp/cpp.txt
@@ -63304,8 +63304,6 @@ REFERENCE_TYPE
 reference_wrapper
 reference_wrappers
 referencing
-Referer
-refering
 refernce
 referral
 ReferralHopLimit

--- a/packages/cpp/cpp.txt
+++ b/packages/cpp/cpp.txt
@@ -23427,7 +23427,6 @@ exhaustive
 exhibited
 EXIF
 exist
-existance
 existant
 existed
 existence

--- a/packages/cpp/cpp.txt
+++ b/packages/cpp/cpp.txt
@@ -63086,7 +63086,6 @@ reception
 receptions
 rechdr
 reciept
-recieve
 recip
 recipe
 recipeCnt

--- a/packages/cpp/cpp.txt
+++ b/packages/cpp/cpp.txt
@@ -60116,7 +60116,6 @@ PRefCon
 prefer
 preferable
 preferably
-prefered
 preference
 PreferencePanes
 preferences

--- a/packages/cpp/cpp.txt
+++ b/packages/cpp/cpp.txt
@@ -57035,10 +57035,7 @@ perpendicular
 PERPETRATOR
 perror
 pers
-persisant
 persist
-persistance
-persistant
 persistence
 persistent
 persistently

--- a/packages/cpp/cpp.txt
+++ b/packages/cpp/cpp.txt
@@ -5385,7 +5385,6 @@ ap_xml_parse_input
 ap__a
 ap__b
 Aqs
-aquired
 aquistion
 AQ_BUFSZ
 aq_delay

--- a/packages/cpp/cpp.txt
+++ b/packages/cpp/cpp.txt
@@ -8556,7 +8556,6 @@ began
 begC
 begin
 begincol
-begining
 beginning
 beginoffset
 begins

--- a/packages/cpp/cpp.txt
+++ b/packages/cpp/cpp.txt
@@ -67954,8 +67954,6 @@ separation
 Separations
 separator
 separators
-seperate
-seperated
 seplen
 seps
 Sept

--- a/packages/cpp/cpp.txt
+++ b/packages/cpp/cpp.txt
@@ -61818,7 +61818,6 @@ pubid
 PubidChar
 pubimbue
 Public
-publically
 publications
 publicID
 publicity

--- a/packages/cpp/cpp.txt
+++ b/packages/cpp/cpp.txt
@@ -79946,7 +79946,6 @@ unintentionally
 uninteresting
 uninterpreted
 uninterruptible
-uninteruptibly
 union
 UnionPlus
 unions

--- a/packages/en_US/en_us.txt
+++ b/packages/en_US/en_us.txt
@@ -79862,8 +79862,6 @@ lollygag
 lollygagged
 lollygagging
 lollygags
-lollypop
-lollypops
 Lombard
 Lombard's
 Lombardi

--- a/packages/en_US/en_us.txt
+++ b/packages/en_US/en_us.txt
@@ -137414,8 +137414,6 @@ Tate's
 tater
 tater's
 taters
-tatoo
-tatoos
 tats
 tatted
 tatter

--- a/packages/en_US/en_us.txt
+++ b/packages/en_US/en_us.txt
@@ -134837,10 +134837,6 @@ supercargo
 supercargo's
 supercargoes
 supercargos
-supercede
-superceded
-supercedes
-superceding
 supercharge
 supercharged
 supercharger

--- a/packages/en_US/en_us.txt
+++ b/packages/en_US/en_us.txt
@@ -68223,7 +68223,6 @@ incidental's
 incidentally
 incidentals
 incidentless
-incidently
 incidents
 incinerate
 incinerated

--- a/packages/en_US/en_us.txt
+++ b/packages/en_US/en_us.txt
@@ -139011,7 +139011,6 @@ thereafter
 thereamong
 thereat
 thereby
-therefor
 therefore
 therefrom
 therein

--- a/packages/en_US/en_us.txt
+++ b/packages/en_US/en_us.txt
@@ -49135,8 +49135,7 @@ fame
 fame's
 famed
 fameless
-fames
-familarity
+fames 
 familia
 familial
 familiar

--- a/packages/en_US/en_us.txt
+++ b/packages/en_US/en_us.txt
@@ -22926,9 +22926,6 @@ chatty
 Chaucer
 Chaucer's
 chaucerian
-chaufers
-chauffer
-chauffers
 chauffeur
 chauffeur's
 chauffeured

--- a/packages/en_US/en_us.txt
+++ b/packages/en_US/en_us.txt
@@ -92667,8 +92667,6 @@ nonobservance
 nonobservance's
 nonobservant
 nonoccupational
-nonoccurence
-nonoccurence
 nonoccurrence
 nonoccurrence's
 nonodorous

--- a/packages/en_US/en_us.txt
+++ b/packages/en_US/en_us.txt
@@ -1521,7 +1521,6 @@ Adenauer's
 adenine
 adenine's
 adenocarcinoma
-adenocarcinoma
 adenoid
 adenoid's
 adenoidal
@@ -4850,7 +4849,6 @@ anesthetist's
 anesthetists
 anesthetization
 anesthetization's
-anesthetizations
 anesthetizations
 anesthetize
 anesthetized
@@ -10446,7 +10444,6 @@ Barack's
 barb
 barb's
 barbacoa
-barbacoa
 Barbadian
 Barbadian's
 Barbadians
@@ -14554,8 +14551,6 @@ blowiness
 blowing
 blowjob
 blowjob's
-blowjob's
-blowjobs
 blowjobs
 blowlamp
 blowlamps
@@ -15139,7 +15134,6 @@ boloneys
 bolos
 Bolshevik
 Bolshevik's
-Bolsheviki
 Bolsheviki
 Bolsheviks
 Bolshevism
@@ -18281,7 +18275,6 @@ buries
 burin
 burins
 burka
-burka's
 burka's
 burkas
 Burke
@@ -22888,8 +22881,6 @@ chatelaines
 chatline
 chatlines
 chatroom
-chatroom
-chatroom's
 chatroom's
 chats
 Chattahoochee
@@ -30741,13 +30732,9 @@ countermeasure
 countermeasure's
 countermeasures
 countermelodies
-countermelodies
-countermelody
 countermelody
 countermen
 countermove
-countermove
-countermoves
 countermoves
 counteroffensive
 counteroffensive's
@@ -32664,7 +32651,6 @@ cultists
 cultivable
 cultivar
 cultivar's
-cultivar's
 cultivars
 cultivatable
 cultivate
@@ -33240,7 +33226,6 @@ Cybele's
 cyberbullies
 cyberbully
 cyberbully's
-cyberbully's
 cybercafe
 cybercafes
 cybercultural
@@ -33392,7 +33377,6 @@ cystic
 cystitis
 cysts
 cytokines
-cytokines
 cytologic
 cytological
 cytologically
@@ -33430,8 +33414,6 @@ czars
 Czech
 Czech's
 Czechia
-Czechia
-Czechia's
 Czechia's
 Czechoslovak
 Czechoslovakia
@@ -42596,8 +42578,6 @@ dyspeptically
 dyspeptics
 dysphagia
 dysphoria
-dysphoria
-dysphoric
 dysphoric
 dysprosium
 dysprosium's
@@ -44494,8 +44474,6 @@ emo
 emo's
 emoji
 emoji's
-emoji's
-emojis
 emojis
 emollient
 emollient's
@@ -44989,7 +44967,6 @@ endomorphic
 endomorphism
 endorphin
 endorphin's
-endorphins
 endorphins
 endorsable
 endorse
@@ -47892,7 +47869,6 @@ exogenous
 exogenously
 exon
 exon's
-exon's
 exonerate
 exonerated
 exonerates
@@ -47902,7 +47878,6 @@ exoneration's
 exonerations
 exonerator
 exonerators
-exons
 exons
 exoplanet
 exoplanet's
@@ -49732,7 +49707,6 @@ feast
 feast's
 feasted
 feaster
-feaster's
 feaster's
 feasters
 feastful
@@ -57853,7 +57827,6 @@ gm
 GM's
 GMAT
 GMO
-GMO
 GMT
 GMT's
 gnarl
@@ -60043,8 +60016,6 @@ guest
 guest's
 guestbook
 guestbook's
-guestbook's
-guestbooks
 guestbooks
 guested
 guesthouse
@@ -60686,7 +60657,6 @@ hacksaw
 hacksaw's
 hacksaws
 hacktivist
-hacktivist's
 hacktivist's
 hacktivists
 hackwork
@@ -63715,8 +63685,6 @@ highwaymen
 highways
 hijab
 hijab's
-hijab's
-hijabs
 hijabs
 hijack
 hijack's
@@ -75829,10 +75797,7 @@ kvetch
 kvetch's
 kvetched
 kvetcher
-kvetcher
 kvetcher's
-kvetcher's
-kvetchers
 kvetchers
 kvetches
 kvetching
@@ -76269,7 +76234,6 @@ lame
 lame's
 lamebrain
 lamebrain's
-lamebrained
 lamebrained
 lamebrains
 lamed
@@ -78059,7 +78023,6 @@ letup's
 letups
 leu
 leucine
-leucine
 leucocyte
 leucoma
 leucotomies
@@ -79764,7 +79727,6 @@ logiest
 logily
 login
 login's
-login's
 loginess
 logins
 logistic
@@ -79781,11 +79743,9 @@ logo
 logo's
 logoff
 logoff's
-logoff's
 logoffs
 logogram
 logon
-logon's
 logon's
 logons
 logorrhea
@@ -79795,7 +79755,6 @@ logotype's
 logotypes
 logotypies
 logout
-logout's
 logout's
 logouts
 logroll
@@ -81312,22 +81271,15 @@ madras
 madras's
 madrasa
 madrasa's
-madrasa's
-madrasah
 madrasah
 madrasah's
-madrasah's
-madrasahs
 madrasahs
 madrasas
 madrases
 madrassa
-madrassa
-madrassa's
 madrassa's
 madrassah
 madrassahs
-madrassas
 madrassas
 madre
 madres
@@ -84298,8 +84250,6 @@ meetness
 meets
 meetup
 meetup's
-meetup's
-meetups
 meetups
 meg
 Meg's
@@ -84562,7 +84512,6 @@ membranes
 membranous
 membranously
 meme
-meme's
 meme's
 memento
 memento's
@@ -85510,10 +85459,7 @@ Micmacs
 micro
 micro's
 microaggression
-microaggression
 microaggression's
-microaggression's
-microaggressions
 microaggressions
 microanalyses
 microanalysis
@@ -86368,7 +86314,6 @@ minimax
 minimaxes
 minimization
 minimization's
-minimization's
 minimize
 minimized
 minimizer
@@ -86744,7 +86689,6 @@ misclassify
 misclassifying
 miscognizant
 miscommunication
-miscommunications
 miscommunications
 misconceive
 misconceived
@@ -87368,7 +87312,6 @@ mizzens
 mizzle
 mizzly
 Mk
-mkay
 mkay
 mks
 mkt
@@ -88994,7 +88937,6 @@ mouthed
 mouther
 mouthers
 mouthfeel
-mouthfeel
 mouthful
 mouthful's
 mouthfuls
@@ -89383,7 +89325,6 @@ multifariousness
 multifariousness's
 multiform
 multifunction
-multigrain
 multigrain
 multiinfection
 multijet
@@ -91042,7 +90983,6 @@ neocolonialists
 neocolonially
 neocon
 neocon's
-neocon's
 neocons
 neoconservative
 neoconservative's
@@ -91114,7 +91054,6 @@ nephritis's
 nephritises
 nephron
 nephrons
-nephropathy
 nephropathy
 nepotic
 nepotism
@@ -91688,7 +91627,6 @@ Nigerians
 Nigerien
 Nigerien's
 nigga
-nigga's
 nigga's
 niggard
 niggard's
@@ -93406,7 +93344,6 @@ NSA
 NSA's
 NSC
 NSF
-NSFW
 NSFW
 NT
 nth
@@ -95547,7 +95484,6 @@ orbits
 orbs
 orc
 orc's
-orc's
 orca
 orcas
 orch
@@ -95711,7 +95647,6 @@ orient
 orient's
 oriental
 oriental's
-Orientalism
 Orientalism
 orientalist
 orientalists
@@ -96069,7 +96004,6 @@ OTC
 Othello
 Othello's
 other
-other's
 other's
 otherness
 others
@@ -98926,7 +98860,6 @@ parklands
 Parkman
 Parkman's
 parkour
-parkour
 parks
 Parks's
 parkway
@@ -99000,7 +98933,6 @@ paroles
 paroling
 parols
 paroquets
-parotid
 parotid
 paroxysm
 paroxysm's
@@ -101533,8 +101465,6 @@ phallically
 phallism
 phallist
 phallocentric
-phallocentric
-phallocentrism
 phallocentrism
 phalloid
 phallus
@@ -101908,7 +101838,6 @@ phosphorous
 phosphors
 phosphorus
 phosphorus's
-phosphorylation
 phosphorylation
 photic
 photics
@@ -104018,7 +103947,6 @@ pod's
 podcast
 podcast's
 podcasting
-podcasting
 podcasts
 podded
 podding
@@ -104427,6 +104355,7 @@ polyester's
 polyesters
 polyethylene
 polyethylene's
+polyfills
 polygamic
 polygamies
 polygamist
@@ -104489,7 +104418,6 @@ polynomial's
 polynomials
 polyp
 polyp's
-polyfills
 Polyphemus
 Polyphemus's
 polyphonic
@@ -105210,7 +105138,6 @@ postseason
 postseason's
 postseasonal
 postseasons
-postsynaptic
 postsynaptic
 posttraumatic
 posttreatment
@@ -106208,7 +106135,6 @@ preform
 preformed
 preforming
 preforms
-prefrontal
 prefrontal
 pregame
 pregame's
@@ -109561,7 +109487,6 @@ pyrotechnics's
 Pyrrhic
 Pyrrhic's
 pyruvate
-pyruvate
 pyruvic
 Pythagoras
 Pythagoras's
@@ -111130,7 +111055,6 @@ ransomer's
 ransomers
 ransoming
 ransoms
-ransomware
 ransomware
 rant
 rant's
@@ -113174,7 +113098,6 @@ reducibly
 reducing
 reductase
 reductase's
-reductase's
 reductio
 reduction
 reduction's
@@ -115078,7 +115001,6 @@ reordering
 reorders
 reorg
 reorg's
-reorg's
 reorganization
 reorganization's
 reorganizations
@@ -116542,12 +116464,8 @@ returners
 returning
 returns
 retweet
-retweet
-retweeted
 retweeted
 retweeting
-retweeting
-retweets
 retweets
 retying
 retype
@@ -117921,7 +117839,6 @@ roble
 Robles
 Robles's
 robocall
-robocall's
 robocall's
 robocalled
 robocalling
@@ -119372,7 +119289,6 @@ ryes
 Ryukyu
 Ryukyu's
 Rz
-Rz
 s
 S's
 SA
@@ -119468,7 +119384,6 @@ sackcloth's
 sackclothed
 sacked
 sacker
-sacker's
 sacker's
 sackers
 sackful
@@ -120101,7 +120016,6 @@ sampler's
 samplers
 samples
 sampling
-sampling's
 sampling's
 samplings
 Sampson
@@ -121907,8 +121821,6 @@ screenplays
 screens
 screensaver
 screensaver's
-screensaver's
-screensavers
 screensavers
 screenshot
 screenshots
@@ -124725,7 +124637,6 @@ shifts
 shifty
 shiitake
 shiitake's
-shiitake's
 shiitakes
 Shiite
 Shiite's
@@ -125065,7 +124976,6 @@ shoots
 shop
 shop's
 shopaholic
-shopaholic's
 shopaholic's
 shopaholics
 shopboy
@@ -126054,7 +125964,6 @@ Silvia
 Silvia's
 sim
 sim's
-sim's
 Simenon
 Simenon's
 simian
@@ -126505,7 +126414,6 @@ sizzling
 SJ
 Sjaelland
 Sjaelland's
-SJW
 SJW
 SK
 ska
@@ -129288,7 +129196,6 @@ soullessly
 soullessness
 soulmate
 soulmate's
-soulmate's
 soulmates
 souls
 sound
@@ -129984,7 +129891,6 @@ spellbinding
 spellbinds
 spellbound
 spellcheck
-spellcheck's
 spellcheck's
 spellchecked
 spellchecker
@@ -132042,7 +131948,6 @@ stenography's
 stenos
 stenosis
 stent
-stent's
 stent's
 stentor
 stentorian
@@ -134764,7 +134669,6 @@ sunbed
 sunbeds
 sunbelt
 sunbelt's
-sunbelts
 sunbelts
 sunbird
 sunbirds
@@ -138946,7 +138850,6 @@ Tharp
 Tharp's
 that
 that'd
-that'd
 that'll
 that's
 thataway
@@ -140032,7 +139935,6 @@ tikes
 tikis
 til
 tilapia
-tilapia
 tilde
 tilde's
 tildes
@@ -140149,12 +140051,8 @@ timeshare
 timeshares
 timesharing
 timestamp
-timestamp
-timestamp's
 timestamp's
 timestamped
-timestamped
-timestamps
 timestamps
 timetable
 timetable's
@@ -140992,7 +140890,6 @@ tool
 tool's
 toolbar
 toolbar's
-toolbars
 toolbars
 toolbox
 toolbox's
@@ -143512,10 +143409,7 @@ trusty's
 truth
 truth's
 truther
-truther
 truther's
-truther's
-truthers
 truthers
 truthful
 truthfully
@@ -143534,7 +143428,6 @@ tryout's
 tryouts
 trypsin
 tryptic
-tryptophan
 tryptophan
 tryptophane
 tryst
@@ -148350,7 +148243,6 @@ user
 user's
 username
 username's
-username's
 usernames
 users
 uses
@@ -150745,7 +150637,6 @@ voicelessness's
 voicemail
 voicemail's
 voicemails
-voicemails
 voiceprint
 voiceprints
 voicer
@@ -150768,7 +150659,6 @@ voila
 voile
 voile's
 voiles
-VoIP
 VoIP
 vol
 volante
@@ -151095,7 +150985,6 @@ wabbles
 wabbly
 Wac
 wack
-wack's
 wack's
 wacker
 wackest
@@ -151914,10 +151803,8 @@ waterbird's
 waterbirds
 waterboard
 waterboard's
-waterboard's
 waterboarded
 waterboarding
-waterboarding's
 waterboarding's
 waterboardings
 waterboards
@@ -152200,10 +152087,7 @@ weaponed
 weaponing
 weaponize
 weaponized
-weaponized
 weaponizes
-weaponizes
-weaponizing
 weaponizing
 weaponless
 weaponries
@@ -153441,7 +153325,6 @@ wider
 wides
 widescreen
 widescreen's
-widescreen's
 widescreens
 widespread
 widest
@@ -153573,8 +153456,6 @@ Wilda
 Wilda's
 wildcard
 wildcard's
-wildcard's
-wildcards
 wildcards
 wildcat
 wildcat's
@@ -156216,7 +156097,6 @@ zigzag's
 zigzagged
 zigzagging
 zigzags
-Zika
 Zika
 zikurat
 zilch

--- a/packages/en_US/en_us.txt
+++ b/packages/en_US/en_us.txt
@@ -119608,7 +119608,6 @@ safe
 safe's
 safecracker
 safecracking
-safegaurds
 safeguard
 safeguard's
 safeguarded

--- a/packages/en_US/en_us.txt
+++ b/packages/en_US/en_us.txt
@@ -146071,7 +146071,6 @@ unformatted
 unformed
 unformulated
 unforsaken
-unforseen
 unfortified
 unfortunate
 unfortunate's

--- a/packages/en_US/en_us.txt
+++ b/packages/en_US/en_us.txt
@@ -153360,7 +153360,6 @@ wieners
 wienie
 wienie's
 wienies
-wierd
 Wiesel
 Wiesel's
 Wiesenthal

--- a/packages/en_US/en_us.txt
+++ b/packages/en_US/en_us.txt
@@ -66764,8 +66764,6 @@ idiomatically
 idioms
 idiopathic
 idiopathy
-idiosyncracies
-idiosyncracy
 idiosyncrasies
 idiosyncrasy
 idiosyncrasy's

--- a/packages/medicalterms/medicalterms-en.txt
+++ b/packages/medicalterms/medicalterms-en.txt
@@ -630,7 +630,7 @@ accommodating
 accommodation
 accommodative
 accommodometer
-accomodation
+accommodation
 accompanying
 accordion
 accordioning

--- a/packages/medicalterms/medicalterms-en.txt
+++ b/packages/medicalterms/medicalterms-en.txt
@@ -60890,7 +60890,6 @@ Millard
 Millard's
 Millar's
 milled
-Millenia
 Miller
 millers'
 Miller's


### PR DESCRIPTION
Cleaned up a few more i hit, removed some duplicates, and went through https://en.oxforddictionaries.com/spelling/common-misspellings for hits