### PR TITLE
Add defstruct to elixir dictionary

### DIFF
--- a/packages/elixir/elixir.txt
+++ b/packages/elixir/elixir.txt
@@ -14,6 +14,7 @@ defoverridable
 defp
 defprotocol
 defspec
+defstruct
 deftype
 deftypep
 

--- a/packages/elixir/elixir.txt
+++ b/packages/elixir/elixir.txt
@@ -56,6 +56,7 @@ nonode
 overridable
 regex
 reraise
+struct
 structs
 typedoc
 typespec


### PR DESCRIPTION
Hey, the defstruct keyword was missing from the elixir dictionary.