### PR TITLE
Improve dictionary spellings. add more companies

### DIFF
--- a/packages/companies/companies.txt
+++ b/packages/companies/companies.txt
@@ -751,11 +751,11 @@ Randstad Holding
 Raytheon
 Raytheon Company
 RBS
-Reactstrap
+reactstrap
 Reaktor
 Realogy Holdings Corp.
 Red Hat, Inc.
-Reddit
+Reddit, Inc.
 Regions Financial Corporation
 Reinsurance Group of America, Incorporated
 Reliance Industries
@@ -961,7 +961,7 @@ UBS
 UGent
 UGI Corporation
 Ultrapar Holdings
-Undraw
+unDraw
 UniCredit Group
 Unilever
 Union Pacific Corporation
@@ -977,7 +977,7 @@ United Technologies
 UnitedHealth Group
 Universal Health Services, Inc.
 Universiteit Gent
-Unpkg
+unpkg
 Unsplash
 Unum Group
 Upcloud Ltd
@@ -995,7 +995,7 @@ VeriSign
 Verisign
 Verizon Communications
 Viacom Inc.
-Vimeo
+Vimeo, Inc.
 Vinci
 Vincit
 Visa Inc.
@@ -1021,7 +1021,7 @@ Western Digital Corporation
 Western Refining, Inc.
 Westpac Banking
 Weyerhaeuser Company
-Whatsapp
+WhatsApp
 Whirlpool Corporation
 Whole Foods Market, Inc.
 Wilmar International
@@ -1039,7 +1039,7 @@ Xbox
 Xcel Energy Inc.
 Xerox
 Xerox Corporation
-Xing
+XING
 Xinxing Cathay International Group
 Xstrata
 Yamada Denki

--- a/packages/companies/companies.txt
+++ b/packages/companies/companies.txt
@@ -76,6 +76,7 @@ Australia & New Zealand Banking Group
 Auto-Owners Insurance Group
 Autoliv, Inc.
 Automatic Data Processing, Inc.
+Automattic Inc.
 AutoNation, Inc.
 AutoZone, Inc.
 Avery Dennison Corporation
@@ -541,6 +542,7 @@ Level 3 Communications, Inc.
 Levis
 LG Electronics
 Liberty Interactive Corporation
+Liberty Media Corporation
 Liberty Mutual Holding Company Inc.
 Liberty Mutual Insurance Group
 Librato
@@ -991,8 +993,7 @@ Vattenfall
 Veikkaus Oy
 Veolia Environnement
 Verdaccio
-VeriSign
-Verisign
+Verisign, Inc.
 Verizon Communications
 Viacom Inc.
 Vimeo, Inc.


### PR DESCRIPTION
- Noticed various spelling issues in the previous Git commits.
- Added more companies to the list, and improved the accuracy of the items.

## Git commits

### fix(companies): improve dictionary spellings

- Fix spelling mistakes
  - Change `Whatsapp` to `WhatsApp`
  - Change `Xing` to `XING`
  - Change `Vimeo` to `Vimeo, Inc.`
  - Change `Unpkg` to `unpkg`
  - Change `Undraw` to `unDraw`
  - Change `Reddit` to `Reddit, Inc.`
  - Change `Reactstrap` to `reactstrap`
    - Even while `reactstrap` is a JavaScript library, not a company...

### feat(companies): add more companies

- Add more companies
  - Add `Automattic Inc.`
  - Add `Snap Inc.`
  - Add `Liberty Media Corporation`
- Fix spelling mistakes
  - Change `Verisign` to `Verisign, Inc.`
- Remove duplicate
  - Remove `VeriSign`
- Maintain list order
  - Run `Sort Lines Ascending` command with VS Code
