### PR TITLE
Support ignoring single quote in c++ hex numbers (#126)

### DIFF
--- a/packages/cpp/cspell-ext.json
+++ b/packages/cpp/cspell-ext.json
@@ -30,7 +30,8 @@
             "includeRegExpList": [],
             // To exclude patterns, add them to "ignoreRegExpList"
             "ignoreRegExpList": [
-                "/#include.*/"
+                "/#include.*/",
+                "/0[xX][0-9a-fA-F](?:'?[0-9a-fA-F])*/"
             ],
             // regex patterns than can be used with ignoreRegExpList or includeRegExpList
             // Example: "pattern": [{ "name": "mdash", "pattern": "&mdash;" }]


### PR DESCRIPTION
Updates cpp's ignoreRegExpList to ignore hex integers.

Fixes #126 