### PR TITLE
Add words to en_US.txt and fullstack.txt

### DIFF
--- a/packages/en_US/src/en_US.txt
+++ b/packages/en_US/src/en_US.txt
@@ -133862,6 +133862,9 @@ submitter
 submitting
 submolecular
 submontane
+subnet
+subnet's
+subnets
 subnormal
 subnormality
 subnormally

--- a/packages/en_US/src/en_US.txt
+++ b/packages/en_US/src/en_US.txt
@@ -104358,6 +104358,7 @@ polyester's
 polyesters
 polyethylene
 polyethylene's
+polyfill
 polyfills
 polygamic
 polygamies

--- a/packages/en_US/src/en_US.txt
+++ b/packages/en_US/src/en_US.txt
@@ -105654,6 +105654,12 @@ preaffirming
 preaffirms
 Preakness
 Preakness's
+preallocate
+preallocated
+preallocates
+preallocating
+preallocation
+preallocations
 preallot
 preallots
 preallotted

--- a/packages/fullstack/fullstack.txt
+++ b/packages/fullstack/fullstack.txt
@@ -107,6 +107,7 @@ paginator
 paren
 parens
 phablet
+polyfill
 polyfills
 prebuilt
 preconnect


### PR DESCRIPTION
I did not see any template for PRs in the contributing guidelines. Please let me know if I didn't do this  correctly.

Copied wordsEnGb.txt to en_US.txt:
* preallocate
* preallocated
* preallocates
* preallocating
* preallocation
* preallocations
* subnet
* subnet's
* subnets

Added `polyfill` to en_US.txt and fullstack.txt (polyfills already existed in both)