### PR TITLE
Add memoize variants

### DIFF
--- a/packages/fullstack/fullstack.txt
+++ b/packages/fullstack/fullstack.txt
@@ -81,6 +81,11 @@ mailto
 maxheight
 maxwidth
 mdash
+memoisation
+memoise
+memoised
+memoization
+memoized
 metatext
 mixitup
 mname


### PR DESCRIPTION
Add variants of the term `memoize`.

`memoize` is currently included in the [Typescript dict](https://github.com/streetsidesoftware/cspell-dicts/blob/master/packages/typescript/typescript.txt), but it is a more general term that is not specific to Typescript. Therefore, I've added the variants in the fullstack dict. 

Let me know if you would like to move the base term `memoize` from the Typescript dict, to the fullstack dict as well 🙂 