### PR TITLE
Add slugify

### DIFF
--- a/packages/software-terms/softwareTerms.txt
+++ b/packages/software-terms/softwareTerms.txt
@@ -427,6 +427,7 @@ sharding
 short
 shortint
 sin
+slugify
 smalltalk
 snackbar
 sort


### PR DESCRIPTION
Add `slugify`

I think it best fits the Software Terms dict.

The term is commonly used, and there are packages and services named `slugify`, which helps in converting a string to a human readable valid url