### PR TITLE
Remove duplicate "map" entry

### DIFF
--- a/packages/software-terms/softwareTerms.txt
+++ b/packages/software-terms/softwareTerms.txt
@@ -308,7 +308,6 @@ Mahalanobis
 make
 manpage
 map
-map
 member
 memcache
 memcached


### PR DESCRIPTION
Found that `map` entry is added twice