### PR TITLE
Remove memoize from Typescript dict

### DIFF
--- a/packages/typescript/typescript.txt
+++ b/packages/typescript/typescript.txt
@@ -603,7 +603,6 @@ mediaquery
 MEETORSLICE
 member
 memberof
-memoize
 method
 methods
 METHODTYPE


### PR DESCRIPTION
Removes memoize from Typescript dict as discussed here #157 

I don't know why zpass has been automatically removed and added (I'm a bit in a hurry and did the change on GitHub website 🙈)