### PR TITLE
Add memoize and its variants

### DIFF
--- a/packages/software-terms/softwareTerms.txt
+++ b/packages/software-terms/softwareTerms.txt
@@ -312,6 +312,12 @@ map
 member
 memcache
 memcached
+memoisation
+memoise
+memoised
+memoization
+memoize
+memoized
 menu
 menubar
 menuitem


### PR DESCRIPTION
Adds `memoize` and its variants to the software terms dict as discussed here #157