### PR TITLE
Add debounced

### DIFF
--- a/packages/software-terms/softwareTerms.txt
+++ b/packages/software-terms/softwareTerms.txt
@@ -98,6 +98,7 @@ ctrlc
 dashboard
 dashboards
 debounce
+debounced
 debug
 debugged
 debugger


### PR DESCRIPTION
debounce was already added, but debounced was missing. 

Often times it is used in naming functions like `linesChangedDebounced` for instance.