### PR TITLE
Add Python strftime and strptime

### DIFF
--- a/packages/python/python.txt
+++ b/packages/python/python.txt
@@ -288,6 +288,8 @@ staticmethod
 StopAsyncIteration
 StopIteration
 str
+strftime
+strptime
 sum
 super
 SyntaxError


### PR DESCRIPTION
Adding Python datetime [strftime](https://docs.python.org/3/library/datetime.html#datetime.date.strftime) and [strptime](https://docs.python.org/3/library/datetime.html#datetime.datetime.strptime)