### PR TITLE
chore: Remove duplicates in Haskell

### DIFF
--- a/packages/haskell/haskell.txt
+++ b/packages/haskell/haskell.txt
@@ -4,14 +4,10 @@ as
 case
 class
 data
-data
-data
 default
-deriving
 deriving
 do
 else
-family
 family
 forall
 foreign
@@ -23,9 +19,6 @@ infix
 infixl
 infixr
 instance
-instance
-instance
-instance
 let
 mdo
 module
@@ -35,8 +28,6 @@ proc
 qualified
 rec
 then
-type
-type
 type
 undefined
 where


### PR DESCRIPTION
Was playing around with `find . -type f -name "*.txt" -exec sh -c "sort -m '{}' | uniq -d" \;`. The other one with a bunch of duplicates is the en-GB dictionary