### PR TITLE
Port over words from aria-practices

### DIFF
--- a/packages/companies/companies.txt
+++ b/packages/companies/companies.txt
@@ -818,6 +818,7 @@ Shandong Weiqiao Pioneering Group
 Shanxi Coal Transportation & Sales Group
 Sharp
 Shenhua Group
+Shopify
 Shougang Group
 Showa Shell Sekiyu
 SHV Holdings

--- a/packages/css/css.txt
+++ b/packages/css/css.txt
@@ -880,6 +880,7 @@ template
 terminator
 text
 textarea
+textfield
 tfoot
 th
 thai

--- a/packages/fullstack/fullstack.txt
+++ b/packages/fullstack/fullstack.txt
@@ -24,7 +24,6 @@ conda
 configurator
 contentful
 coworking
-crossorigin
 datepicker
 deallocate
 deregister

--- a/packages/html/html.txt
+++ b/packages/html/html.txt
@@ -119,6 +119,7 @@ commit
 complementary
 constant
 content
+contenteditable
 contentinfo
 css
 data

--- a/packages/html/html.txt
+++ b/packages/html/html.txt
@@ -36,6 +36,7 @@ aria-grabbed
 aria-haspopup
 aria-hidden
 aria-invalid
+aria-kbdshortcuts
 aria-keyshortcuts
 aria-label
 aria-labelledby

--- a/packages/html/html.txt
+++ b/packages/html/html.txt
@@ -164,6 +164,7 @@ fieldset
 figcaption
 figure
 file
+focusable
 font
 footer
 form

--- a/packages/html/html.txt
+++ b/packages/html/html.txt
@@ -121,6 +121,7 @@ constant
 content
 contenteditable
 contentinfo
+crossorigin
 css
 data
 datalist

--- a/packages/html/html.txt
+++ b/packages/html/html.txt
@@ -6,6 +6,7 @@ acronym
 address
 after
 ajax
+alertdialog
 ampersand
 and
 angle

--- a/packages/html/html.txt
+++ b/packages/html/html.txt
@@ -341,6 +341,7 @@ sup
 support
 switch
 tab
+tabindex
 table
 tablist
 tabpanel

--- a/packages/html/html.txt
+++ b/packages/html/html.txt
@@ -133,6 +133,7 @@ definition
 del
 details
 dfn
+DHTML
 dir
 directory
 disabled

--- a/packages/html/html.txt
+++ b/packages/html/html.txt
@@ -387,5 +387,6 @@ wbr
 week
 with
 xhtml
+xlink
 xml
 xmlns

--- a/packages/html/html.txt
+++ b/packages/html/html.txt
@@ -106,6 +106,7 @@ cite
 code
 col
 colgroup
+colheader
 color
 colspan
 columnheader

--- a/packages/software-terms/softwareTerms.txt
+++ b/packages/software-terms/softwareTerms.txt
@@ -131,6 +131,7 @@ colorizers
 combinable
 combinables
 combinatorics
+comboboxes
 commonjs
 compile
 compiler

--- a/packages/software-terms/softwareTerms.txt
+++ b/packages/software-terms/softwareTerms.txt
@@ -523,6 +523,7 @@ Linode
 lint
 linter
 linux
+listboxes
 ln
 localhost
 lock

--- a/packages/software-terms/softwareTerms.txt
+++ b/packages/software-terms/softwareTerms.txt
@@ -362,6 +362,7 @@ greps
 groovy
 groupadd
 guid
+GUIs
 gunzip
 gzip
 handlebars

--- a/packages/software-terms/softwareTerms.txt
+++ b/packages/software-terms/softwareTerms.txt
@@ -98,6 +98,7 @@ calc
 calcs
 callbackfn
 callee
+Capitan
 captcha
 CDATA
 CentOS

--- a/packages/software-terms/softwareTerms.txt
+++ b/packages/software-terms/softwareTerms.txt
@@ -80,6 +80,8 @@ bookmark
 bookmarked
 bookmarker
 bookmarking
+bookmarklet
+bookmarklets
 bookmarks
 bool
 boolean

--- a/packages/software-terms/softwareTerms.txt
+++ b/packages/software-terms/softwareTerms.txt
@@ -571,6 +571,7 @@ memoizes
 memoizing
 menu
 menubar
+menubars
 menuitem
 MERCHANTABLITY
 meta


### PR DESCRIPTION
Not everything in the dictionary is general to everything, but there were some missing HTML attributes/property names and some general software terms that made sense in the various dictionaries.
One part I wasn't sure about is for words that have to do with SVG properties/attributes. I put them in the HTML dictionary, but maybe it should have its own