### PR TITLE
fix: http - make the aria patterns global

### DIFF
--- a/packages/html/cspell-ext.json
+++ b/packages/html/cspell-ext.json
@@ -14,6 +14,59 @@
     // Dictionaries to always be used.
     // Generally left empty
     "dictionaries": [],
+    // regex patterns than can be used with ignoreRegExpList or includeRegExpList
+    // Example: "pattern": [{ "name": "mdash", "pattern": "&mdash;" }]
+    // This could be included in "ignoreRegExpList": ["mdash"]
+    "patterns": [
+        {
+            "name": "HTML-id",
+            "pattern": "/\\bid=\"[^\"]*\"/gi"
+        },
+        {
+            "name": "HTML-src",
+            "pattern": "/\\bsrc=\"[^\"]*\"/gi"
+        },
+        {
+            "name": "HTML-class",
+            "pattern": "/\\bclass=\"[^\"]*\"/gi"
+        },
+        {
+            "name": "HTML-IDREF-aria-activedescendant",
+            "pattern": "/\\baria-activedescendant=\"[^\"]*\"/gi"
+        },
+        {
+            "name": "HTML-IDREF-aria-controls",
+            "pattern": "/\\baria-controls=\"[^\"]*\"/gi"
+        },
+        {
+            "name": "HTML-IDREF-aria-describedby",
+            "pattern": "/\\baria-describedby=\"[^\"]*\"/gi"
+        },
+        {
+            "name": "HTML-IDREF-aria-details",
+            "pattern": "/\\baria-details=\"[^\"]*\"/gi"
+        },
+        {
+            "name": "HTML-IDREF-aria-errormessage",
+            "pattern": "/\\baria-errormessage=\"[^\"]*\"/gi"
+        },
+        {
+            "name": "HTML-IDREF-aria-flowto",
+            "pattern": "/\\baria-flowto=\"[^\"]*\"/gi"
+        },
+        {
+            "name": "HTML-IDREF-aria-labelledby",
+            "pattern": "/\\baria-labelledby=\"[^\"]*\"/gi"
+        },
+        {
+            "name": "HTML-IDREF-aria-owns",
+            "pattern": "/\\baria-owns=\"[^\"]*\"/gi"
+        },
+        {
+            "name": "HTML-IDREF-for",
+            "pattern": "/\\bfor=\"[^\"]*\"/gi"
+        }
+    ],
     // Language Rules to apply to matching files.
     // Files are matched on `languageId` and `local`
     "languageSettings": [
@@ -30,7 +83,7 @@
             // To exclude patterns, add them to "ignoreRegExpList"
             "ignoreRegExpList": [
                 "href",
-                "HTML-IDREF-id",
+                "HTML-id",
                 "HTML-src",
                 "HTML-class",
                 "HTML-IDREF-aria-activedescendant",
@@ -42,59 +95,6 @@
                 "HTML-IDREF-aria-labelledby",
                 "HTML-IDREF-aria-owns",
                 "HTML-IDREF-for"
-            ],
-            // regex patterns than can be used with ignoreRegExpList or includeRegExpList
-            // Example: "pattern": [{ "name": "mdash", "pattern": "&mdash;" }]
-            // This could be included in "ignoreRegExpList": ["mdash"]
-            "patterns": [
-                {
-                    "name": "HTML-IDREF-id",
-                    "pattern": "id=\"(?:[^\\\"]+|\\.)*\""
-                },
-                {
-                    "name": "HTML-src",
-                    "pattern": "src=\"(?:[^\\\"]+|\\.)*\""
-                },
-                {
-                    "name": "HTML-class",
-                    "pattern": "class=\"(?:[^\\\"]+|\\.)*\""
-                },
-                {
-                    "name": "HTML-IDREF-aria-activedescendant",
-                    "pattern": "aria-activedescendant=\"(?:[^\\\"]+|\\.)*\""
-                },
-                {
-                    "name": "HTML-IDREF-aria-controls",
-                    "pattern": "aria-controls=\"(?:[^\\\"]+|\\.)*\""
-                },
-                {
-                    "name": "HTML-IDREF-aria-describedby",
-                    "pattern": "aria-describedby=\"(?:[^\\\"]+|\\.)*\""
-                },
-                {
-                    "name": "HTML-IDREF-aria-details",
-                    "pattern": "aria-details=\"(?:[^\\\"]+|\\.)*\""
-                },
-                {
-                    "name": "HTML-IDREF-aria-errormessage",
-                    "pattern": "aria-errormessage=\"(?:[^\\\"]+|\\.)*\""
-                },
-                {
-                    "name": "HTML-IDREF-aria-flowto",
-                    "pattern": "aria-flowto=\"(?:[^\\\"]+|\\.)*\""
-                },
-                {
-                    "name": "HTML-IDREF-aria-labelledby",
-                    "pattern": "aria-labelledby=\"(?:[^\\\"]+|\\.)*\""
-                },
-                {
-                    "name": "HTML-IDREF-aria-owns",
-                    "pattern": "aria-owns=\"(?:[^\\\"]+|\\.)*\""
-                },
-                {
-                    "name": "HTML-IDREF-for",
-                    "pattern": "for=\"(?:[^\\\"]+|\\.)*\""
-                }
             ],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": [


### PR DESCRIPTION
Make the patterns global and simplify the RegExp.

`\b` added to prevent false matches.
`[^"]` use to match everything till the next `"`
`/gi` to make sure it is global and case insensitive.