### PR TITLE
fix: add datadog company name and stock symbol

### DIFF
--- a/packages/companies/companies.txt
+++ b/packages/companies/companies.txt
@@ -436,10 +436,12 @@ Danaher Corporation
 Danone
 Darden Restaurants
 Darden Restaurants, Inc.
+Datadog
 Datorama
 DaVita HealthCare Partners Inc.
 DaVita Inc.
 Dayjs
+DDOG
 Dean Foods Company
 Deere
 Deere & Co.


### PR DESCRIPTION
I had these for the longest time in my local dictionary
Having them in the global dictionary would make much more sense

See https://en.wikipedia.org/wiki/Datadog and https://www.datadoghq.com