### PR TITLE
chore: Run npm init on generator-cspell-dicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cspell-dicts
 
-Various [cspell](https://github.com/Jason3S/cspell) dictionaries. Each dictionary is its own package. See `README.md` in each directory.
+Various [cspell](https://github.com/streetsidesoftware/cspell) dictionaries. Each dictionary is its own package. See `README.md` in each directory.
 
 ## Language Dictionaries
 

--- a/cSpell.json
+++ b/cSpell.json
@@ -6,22 +6,18 @@
     "language": "en",
     // words - list of words to be always considered correct
     "words": [
-        "addrtype",
         "ALLCAPS",
         "appname",
         "configstore",
         "django",
-        "django's",
-        "Mutex",
-        "shasum",
-        "xargs"
+        "django's"
     ],
     // flagWords - list of words to be always considered incorrect
     "flagWords": [],
     "maxNumberOfProblems": 1000,
     "ignorePaths": [
         "**/node_modules/**",
-        "**/vscode-extension/**",
+        "**/node_modules/package*.json",
         "**/.git/**",
         ".vscode"
     ],
@@ -59,9 +55,5 @@
             "filename": "**/sv/**",
             "language": "en,sv"
         }
-    ],
-    "enableFiletypes": [
-        "ada",
-        "shellscript"
     ]
 }

--- a/generator-cspell-dicts/package.json
+++ b/generator-cspell-dicts/package.json
@@ -29,10 +29,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Jason3S/cspell-dicts.git"
+    "url": "git+https://github.com/streetsidesoftware/cspell-dicts.git"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Jason3S/cspell-dicts/issues"
+    "url": "https://github.com/streetsidesoftware/cspell-dicts/issues"
   }
 }

--- a/generator-cspell-dicts/package.json
+++ b/generator-cspell-dicts/package.json
@@ -4,11 +4,7 @@
   "description": "Generate cspell dictionary subprojects.",
   "homepage": "https://github.com/streetsidesoftware/cspell-dicts",
   "private": true,
-  "author": {
-    "name": "Jason Dent",
-    "email": "jason@streetsidesoftware.nl",
-    "url": ""
-  },
+  "author": "Jason Dent <jason@streetsidesoftware.nl>",
   "files": [
     "generators"
   ],
@@ -31,6 +27,12 @@
     "prepublishOnly": "npm audit",
     "test": "echo no tests"
   },
-  "repository": "git@github.com:Jason3S/cspell-dicts.git",
-  "license": "MIT"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Jason3S/cspell-dicts.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Jason3S/cspell-dicts/issues"
+  }
 }

--- a/packages/de_DE/README.md
+++ b/packages/de_DE/README.md
@@ -48,4 +48,4 @@ The Hunspell source for this dictionary can be found:
 ## License
 
 MIT
-See also: [German_de_DE.txt](https://github.com/Jason3S/cspell-dicts/blob/master/de_DE/German_de_DE.txt)
+See also: [German_de_DE.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/master/packages/de_DE/German_de_DE.txt)

--- a/packages/fr_FR/README.md
+++ b/packages/fr_FR/README.md
@@ -49,4 +49,4 @@ The Hunspell source for this dictionary can be found:
 
 MIT
 
-See also: [French.txt](https://github.com/Jason3S/cspell-dicts/blob/master/fr_FR/French.txt)
+See also: [French.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/master/packages/fr_FR/French.txt)


### PR DESCRIPTION
Had a warning is VSCode around the empty URL, so I just reran `npm init -y` to clean up to the latest schema. Manually updated the repository afterwards from `git+ssh` to `git+https` format