### PR TITLE
fix: Add longdesc to HTML dict

### DIFF
--- a/dictionaries/html/html.txt
+++ b/dictionaries/html/html.txt
@@ -232,6 +232,7 @@ list
 listbox
 listitem
 literal
+longdesc
 mailto
 main
 map


### PR DESCRIPTION
Slowly working through the new https://github.com/mdn/content and this was the first one that I saw that was probably "missing"
I'll probably try and gather others up later in a larger batch if I find more

Wasn't sure if this should also go in `packages/html` too or not