### PR TITLE
fix: Add pytest to Python dictionaries

### DIFF
--- a/dictionaries/python/python.txt
+++ b/dictionaries/python/python.txt
@@ -284,6 +284,7 @@ property
 pygments
 pypi
 pypy
+pytest
 quit
 raise
 range

--- a/packages/python/python.txt
+++ b/packages/python/python.txt
@@ -257,6 +257,7 @@ property
 pygments
 pypi
 pypy
+pytest
 quit
 raise
 range


### PR DESCRIPTION
noticed it in the Scientific and Medical dictionaries, but thought it made sense here