### PR TITLE
fix: Move 'transpile' to softwareTerms dictionary

### DIFF
--- a/dictionaries/software-terms/softwareTerms.txt
+++ b/dictionaries/software-terms/softwareTerms.txt
@@ -1194,7 +1194,7 @@ transparent
 transparentize
 transpilation
 transpile
-Transpile
+transpiled
 transpiler
 transpilers
 tree

--- a/dictionaries/software-terms/softwareTerms.txt
+++ b/dictionaries/software-terms/softwareTerms.txt
@@ -1192,7 +1192,11 @@ transcluded
 transclusion
 transparent
 transparentize
+transpilation
+transpile
 Transpile
+transpiler
+transpilers
 tree
 trees
 trie

--- a/dictionaries/typescript/typescript.txt
+++ b/dictionaries/typescript/typescript.txt
@@ -3262,11 +3262,6 @@ translate
 translated
 translation
 transparent
-transpilation
-transpile
-Transpile
-transpiler
-transpilers
 transport
 transports
 transpose


### PR DESCRIPTION
It cause problems for us since we use this word inside our README.md