### PR TITLE
en_US spelling of constitutional

### DIFF
--- a/dictionaries/en_US/src/en_US.txt
+++ b/dictionaries/en_US/src/en_US.txt
@@ -3893,7 +3893,6 @@ consenter
 consenters
 consignataries
 consistorial
-consitutional
 consolers
 consommes
 consortiums
@@ -3901,6 +3900,7 @@ consortship
 conspirer
 conspirers
 conspiringly
+constitutional
 constrainedly
 constrainers
 constrainment


### PR DESCRIPTION
Looks like constitutional was missing the first 't' in the en_US dictionary.