### PR TITLE
Add "sdk" and "sdks" to software terms dictionary.

### DIFF
--- a/dictionaries/software-terms/softwareTerms.txt
+++ b/dictionaries/software-terms/softwareTerms.txt
@@ -1072,6 +1072,8 @@ scrollable
 scrollbar
 scss
 scutil
+sdk
+sdks
 secedit
 selinux
 sematic


### PR DESCRIPTION
"SDK" stands for software development kit.