### PR TITLE
Add "Unlicense" to software terms dictionary.

### DIFF
--- a/dictionaries/software-terms/softwareTerms.txt
+++ b/dictionaries/software-terms/softwareTerms.txt
@@ -1283,6 +1283,7 @@ unencoded
 unescape
 unescaped
 unfavorite
+Unlicense
 Unhandled
 unicast
 unindent


### PR DESCRIPTION
See https://unlicense.org/.