### PR TITLE
Add "appxmanifest" to dotnet dictionary.

### DIFF
--- a/dictionaries/dotnet/dotnet.txt
+++ b/dictionaries/dotnet/dotnet.txt
@@ -9778,6 +9778,7 @@ ZoomInCommand
 ZoomOut
 ZoomOutCommand
 abstract
+appxmanifest
 bool
 bool>>;
 byte


### PR DESCRIPTION
This is the extension of the package manifest file for Universal Windows Platform apps.