### PR TITLE
Add "nvmrc" to npm dictionary.

### DIFF
--- a/dictionaries/npm/npm.txt
+++ b/dictionaries/npm/npm.txt
@@ -477,6 +477,7 @@ nsp
 numeral
 nunjucks
 nvm
+nvmrc
 nyc
 oauth
 object-assign


### PR DESCRIPTION
.nvmrc is the name of the configuration file for Node Version Manager.