### PR TITLE
Add "appx" to file types dictionary.

### DIFF
--- a/dictionaries/filetypes/filetypes.txt
+++ b/dictionaries/filetypes/filetypes.txt
@@ -10,6 +10,7 @@ aifc
 aiff
 apib
 apiblueprint
+appx
 appxmanifest
 ascx
 asp


### PR DESCRIPTION
"appxmanifest" is written as "AppxManifest" in Universal Windows Platform (UWP) build config files.