### PR TITLE
Add "Appx" to dotnet dictionary.

### DIFF
--- a/dictionaries/dotnet/dotnet.txt
+++ b/dictionaries/dotnet/dotnet.txt
@@ -411,6 +411,7 @@ AppliedDeviceFiltersDialog_DefaultFilterAlreadyApplied
 AppliedDeviceFiltersDialog_DuplicateChoices
 AppliedDeviceFiltersDialog_Title
 Apply
+Appx
 Arg_ArrayPlusOffTooSmall
 Arg_CannotCreateNode
 Arg_ExpectingXmlTextReader


### PR DESCRIPTION
"appxmanifest" is written as "AppxManifest" in Universal Windows Platform (UWP) build config files.