### PR TITLE
Add words from msbuild properties to dotnet dict.

### DIFF
--- a/dictionaries/dotnet/dotnet.txt
+++ b/dictionaries/dotnet/dotnet.txt
@@ -4931,6 +4931,7 @@ NestedAggregateCannotBeUsedInAggregate
 NestedClassNotSupported
 Nested_group_not_valid
 NetBios_command_limit_reached
+NetFx
 NewArrayExpressionProxy
 NewExpression
 NewExpressionProxy
@@ -7777,6 +7778,7 @@ ToolZone_InstructionText
 ToolZone_InstructionTextStyle
 ToolZone_LabelStyle
 Toolbox_TabName
+Toolchain
 Top
 TopAndLimitCannotCoexist
 TopAndSkipCannotCoexist
@@ -9811,6 +9813,7 @@ object
 operator
 override
 partial
+pdbonly
 propertyChangedEventDescr
 public
 readonly


### PR DESCRIPTION
"NetFx" is an abbreviation for .NET Framework.
"pdbonly" is a value of the build property DebugType.
"Toolchain" is part of the build property UseDotNetNativeToolchain.