### PR TITLE
Add icon filename verbiage to dotnet dictionary.

### DIFF
--- a/dictionaries/dotnet/dotnet.txt
+++ b/dictionaries/dotnet/dotnet.txt
@@ -9778,6 +9778,7 @@ ZoomInCommand
 ZoomOut
 ZoomOutCommand
 abstract
+altform
 appxmanifest
 bool
 bool>>;
@@ -9817,9 +9818,11 @@ readonly
 sealed
 static
 string
+targetsize
 this
 tooManyAttributesOfTypeOn2
 true;
+unplated
 virtual
 void
 {


### PR DESCRIPTION
Add "altform," "targetsize," and "unplated."