### PR TITLE
Add icon filename verbiage to file types dict.

### DIFF
--- a/dictionaries/filetypes/filetypes.txt
+++ b/dictionaries/filetypes/filetypes.txt
@@ -8,6 +8,7 @@ adts
 aif
 aifc
 aiff
+altform
 apib
 apiblueprint
 appx
@@ -256,6 +257,7 @@ swift
 sys
 t
 targets
+targetsize
 tif
 tiff
 tld
@@ -269,6 +271,7 @@ ttf
 txt
 typescript
 typescriptreact
+unplated
 vb
 vbproj
 vbprojuser


### PR DESCRIPTION
Add "altform," "targetsize," and "unplated."