### PR TITLE
Add "dotnettools" to dotnet dictionary.

### DIFF
--- a/dictionaries/dotnet/dotnet.txt
+++ b/dictionaries/dotnet/dotnet.txt
@@ -9786,6 +9786,7 @@ class
 collectionChangedEventDescr
 const
 couldnTFindRequiredAttributeOfTypeOn2
+dotnettools
 double
 enum
 event


### PR DESCRIPTION
This is part of a Microsoft namespace for popular VSCode extensions.