### PR TITLE
Add some linters to python dictionary.

### DIFF
--- a/dictionaries/python/python.txt
+++ b/dictionaries/python/python.txt
@@ -130,8 +130,10 @@ atan2
 atanh
 AttributeError
 autoreset
+bandit
 BaseException
 bin
+black
 BlockingIOError
 bool
 break
@@ -230,6 +232,7 @@ finally
 find
 finditer
 fixture
+flake8
 float
 FloatingPointError
 floor
@@ -256,6 +259,7 @@ getattr
 getctime
 getcwd
 getpass
+gjslint
 global
 globals
 groupby
@@ -306,6 +310,7 @@ islower
 ismount
 isnan
 isnumeric
+isort
 isprintable
 isqrt
 isspace
@@ -351,6 +356,7 @@ map
 mark
 math
 max
+mccabe
 MemoryError
 memoryview
 metavar
@@ -385,6 +391,8 @@ param
 partition
 pass
 PendingDeprecationWarning
+pep8
+pep257
 perm
 PermissionError
 permutations
@@ -398,13 +406,20 @@ ProcessLookupError
 prod
 product
 property
+prospector
+pycodestyle
+pydocstyle
+pyflakes
 pygments
+pylama
+pylint
 pypi
 pypy
 pytest
 pytest
 quit
 radians
+radon
 raise
 raises
 range


### PR DESCRIPTION
Add "bandit," "black," "flake8," "gjslint," "isort," "mccabe," "pep8," "pep257," "prospector," "pycodestyle," "pydocstyle," "pyflakes," "pylama," "pylint," and "radon."