### PR TITLE
Add some pipenv terminology to python dictionary.

### DIFF
--- a/dictionaries/python/python.txt
+++ b/dictionaries/python/python.txt
@@ -116,6 +116,7 @@ all
 and
 any
 APPDATA
+appdirs
 approx
 argparse
 ArithmeticError
@@ -397,10 +398,14 @@ perm
 PermissionError
 permutations
 pi
+pipenv
+pipfile
+pipx
 pop
 posix
 pow
 pow
+prereleases
 print
 ProcessLookupError
 prod
@@ -523,6 +528,8 @@ UserWarning
 utime
 ValueError
 vars
+venv
+virtualenv
 Warning
 warns
 while


### PR DESCRIPTION
Add "appdirs," "pipenv," "pipfile," "pipx," "prereleases," "venv," and "virtualenv."