### PR TITLE
fix: Make it easier to turn off the public-licenses dictionary

### DIFF
--- a/dictionaries/public-licenses/cspell-ext.json
+++ b/dictionaries/public-licenses/cspell-ext.json
@@ -13,7 +13,7 @@
             "description": "Common Public Licenses dictionary for cspell."
         }
     ],
-    // Turn on the dictinary by default.
+    // Turn on the dictionary by default.
     // It can be turned off using `"dictionaries": ["!public-licenses"]
     "dictionaries": ["public-licenses"],
     "languageSettings": []

--- a/dictionaries/public-licenses/cspell-ext.json
+++ b/dictionaries/public-licenses/cspell-ext.json
@@ -9,36 +9,12 @@
     "dictionaryDefinitions": [
         {
             "name": "public-licenses",
-            "file": "./public-licenses.txt.gz",
+            "path": "./public-licenses.txt.gz",
             "description": "Common Public Licenses dictionary for cspell."
         }
     ],
-    // Dictionaries to always be used.
-    // Generally left empty
-    "dictionaries": [],
-    // Language Rules to apply to matching files.
-    // Files are matched on `languageId` and `local`
-    "languageSettings": [
-        {
-            // VSCode languageId. i.e. typescript, java, go, cpp, javascript, markdown, latex
-            // * will match against any file type.
-            "languageId": "*",
-            // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
-            // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
-            // By default the whole text of a file is included for spell checking
-            // Adding patterns to the "includeRegExpList" to only include matching patterns
-            "includeRegExpList": [],
-            // To exclude patterns, add them to "ignoreRegExpList"
-            "ignoreRegExpList": [],
-            // regex patterns than can be used with ignoreRegExpList or includeRegExpList
-            // Example: "pattern": [{ "name": "mdash", "pattern": "&mdash;" }]
-            // This could be included in "ignoreRegExpList": ["mdash"]
-            "patterns": [],
-            // List of dictionaries to enable by name in `dictionaryDefinitions`
-            "dictionaries": ["public-licenses"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
-            "dictionaryDefinitions": []
-        }
-    ]
+    // Turn on the dictinary by default.
+    // It can be turned off using `"dictionaries": ["!public-licenses"]
+    "dictionaries": ["public-licenses"],
+    "languageSettings": []
 }

--- a/dictionaries/public-licenses/cspell.json
+++ b/dictionaries/public-licenses/cspell.json
@@ -1,7 +1,6 @@
 {
     "version": "0.2",
     "files": ["**/*.{md,txt}"],
-    "dictionaries": ["public-licenses"],
     "words": ["readonly", "xargs", "shasum"],
     "import": ["./cspell-ext.json"]
 }

--- a/dictionaries/public-licenses/cspell.json
+++ b/dictionaries/public-licenses/cspell.json
@@ -1,6 +1,6 @@
 {
     "version": "0.2",
-    "files": ["**/*.{md,txt}"],
+    "files": ["**/*.{md,txt,json}"],
     "words": ["readonly", "xargs", "shasum"],
     "import": ["./cspell-ext.json"]
 }

--- a/generator-cspell-dicts/generators/app/templates/cspell-ext.json
+++ b/generator-cspell-dicts/generators/app/templates/cspell-ext.json
@@ -9,7 +9,7 @@
     "dictionaryDefinitions": [
         {
             "name": "<%= packageName %>",
-            "file": "./<%= dstFileName %>",
+            "path": "./<%= dstFileName %>",
             "description": "<%= description %>"
         }
     ],


### PR DESCRIPTION
- Add `"public-licenses"` to `"dictionaries"` instead of `"languageSettings"`
- fix dictionary definition to use `path` instead of `file`