### PR TITLE
Add "targetnametoken" to dotnet dictionary.

### DIFF
--- a/dictionaries/dotnet/dotnet.txt
+++ b/dictionaries/dotnet/dotnet.txt
@@ -9825,6 +9825,7 @@ ReSharper
 sealed
 static
 string
+targetnametoken
 targetsize
 this
 tooManyAttributesOfTypeOn2


### PR DESCRIPTION
This is a variable used in the manifest of a UWP (Universal Windows Platform) app that resolves to the filename of the executable upon building.