### PR TITLE
Add "cyrl," "hant," and "latn" to file types dict.

### DIFF
--- a/dictionaries/filetypes/filetypes.txt
+++ b/dictionaries/filetypes/filetypes.txt
@@ -60,6 +60,7 @@ css
 csv
 ctp
 cxx
+cyrl
 dif
 diff
 dita
@@ -108,6 +109,7 @@ gyp
 gypi
 h
 handlebars
+hant
 haskell
 hbs
 hh
@@ -142,6 +144,7 @@ jsonc
 jsp
 jsx
 jsxtags
+latn
 launch
 less
 lua


### PR DESCRIPTION
These are portions of language codes that can end up in file extensions. "cyrl" means "Cyrillic," "hant" refers to the Traditional script (e.g., of Chinese), and "latn" means "Latin."