### PR TITLE
Add "ghcr" and "githooks" to software terms dict.

### DIFF
--- a/dictionaries/software-terms/softwareTerms.txt
+++ b/dictionaries/software-terms/softwareTerms.txt
@@ -463,11 +463,13 @@ Gemfile
 gemfiles
 geojson
 getter
+ghcr
 gimsuy
 git
 git-commit
 git-rebase
 git's
+githooks
 github
 githubusercontent
 gitignore


### PR DESCRIPTION
"ghcr" stands for GitHub Container registry, which is where GitHub Packages are hosted. "githooks" are commit hooks used by Git.