### PR TITLE
Add "NETFX" to dotnet dictionary.

### DIFF
--- a/dictionaries/dotnet/dotnet.txt
+++ b/dictionaries/dotnet/dotnet.txt
@@ -4934,6 +4934,7 @@ NestedClassNotSupported
 Nested_group_not_valid
 NetBios_command_limit_reached
 NetFx
+NETFX
 NewArrayExpressionProxy
 NewExpression
 NewExpressionProxy


### PR DESCRIPTION
"NETFX" is an abbreviation for .NET Framework commonly found in .csproj files. Since .csproj files are themselves XML files and cspell disallows compound words by default in XML files, the existing dictionary entry "NetFx" does not match "NETFX."