### PR TITLE
fix: Add Hacktoberfest to software terms

### DIFF
--- a/dictionaries/software-terms/softwareTerms.txt
+++ b/dictionaries/software-terms/softwareTerms.txt
@@ -503,6 +503,7 @@ guid
 GUIs
 gunzip
 gzip
+Hacktoberfest
 hacky
 handlebars
 haproxy


### PR DESCRIPTION
It is more of a specific marketing thing, but I say it added into the custom words on another repo