### PR TITLE
Remove some duplicates from python dictionary.

### DIFF
--- a/dictionaries/python/python.txt
+++ b/dictionaries/python/python.txt
@@ -405,7 +405,6 @@ pipx
 pop
 posix
 pow
-pow
 prereleases
 print
 ProcessLookupError
@@ -421,7 +420,6 @@ pylama
 pylint
 pypi
 pypy
-pytest
 pytest
 quit
 radians


### PR DESCRIPTION
"pow" and "pytest" both appeared twice in a row.