### PR TITLE
Add "unimported" to Python dictionary.

### DIFF
--- a/dictionaries/python/python.txt
+++ b/dictionaries/python/python.txt
@@ -519,6 +519,7 @@ UnicodeEncodeError
 UnicodeError
 UnicodeTranslateError
 UnicodeWarning
+unimported
 union
 update
 upper


### PR DESCRIPTION
Mypy offers a disallow_any_unimported option.