### PR TITLE
Add "fileio" to software terms dictionary.

### DIFF
--- a/dictionaries/software-terms/softwareTerms.txt
+++ b/dictionaries/software-terms/softwareTerms.txt
@@ -420,6 +420,7 @@ Fallthrough
 Falsy
 ffmpeg
 file
+fileio
 filename
 filenames
 filepath


### PR DESCRIPTION
Mega-Linter has a configuration option named `FILEIO_REPORTER`.