### PR TITLE
Add "noqa" and "nosec" to Python dictionary.

### DIFF
--- a/dictionaries/python/python.txt
+++ b/dictionaries/python/python.txt
@@ -378,6 +378,8 @@ next
 noinspection
 None
 nonlocal
+noqa
+nosec
 not
 NotADirectoryError
 NotImplemented


### PR DESCRIPTION
These are inline directives to disable linters.