### PR TITLE
Add some Docker words to software terms dictionary

### DIFF
--- a/dictionaries/software-terms/softwareTerms.txt
+++ b/dictionaries/software-terms/softwareTerms.txt
@@ -338,8 +338,10 @@ dlls
 dmesg
 dmidecode
 DNS
+docker
 dockerd
 dockerfile
+dockerize
 docstring
 doctype
 DOM

--- a/dictionaries/software-terms/softwareTerms.txt
+++ b/dictionaries/software-terms/softwareTerms.txt
@@ -338,6 +338,7 @@ dlls
 dmesg
 dmidecode
 DNS
+dockerd
 dockerfile
 docstring
 doctype
@@ -1149,6 +1150,7 @@ server
 serverless
 set
 setter
+setuptool
 sftp
 sha
 SHA256


### PR DESCRIPTION
Add "dockerd" and "setuptool" from dockerd-rootless-setuptool.sh.