### PR TITLE
Add "SCRIPTDIR" to Bash dictionary.

### DIFF
--- a/dictionaries/bash/bash-words.txt
+++ b/dictionaries/bash/bash-words.txt
@@ -35,6 +35,7 @@ physical
 pipefail
 posix
 privileged
+SCRIPTDIR
 select
 shellcheck
 shfmt


### PR DESCRIPTION
SCRIPTDIR is the path to the current script in ShellCheck.