### PR TITLE
Replace licence forms to license in en_US

### DIFF
--- a/dictionaries/en_US/src/en_US.txt
+++ b/dictionaries/en_US/src/en_US.txt
@@ -10985,13 +10985,13 @@ libretti
 libris
 libs
 license
-licenses
 licensee
 licensees
-licensing
 licenseless
 licenser
 licensers
+licenses
+licensing
 licensor
 licensors
 licensure


### PR DESCRIPTION
Fixes #711

Replacing "licence" (GB) ([source](https://en.wiktionary.org/wiki/licence)) with "license" (US) ([source](https://en.wiktionary.org/wiki/license)), and adding plural "licenses".

([This source](https://www.ldoceonline.com/dictionary/licensor#:~:text=From%20Longman%20Business%20Dictionaryli,which%20to%20issue%20a%20license.)) says that "licenser" is GB, but I can't find any other sources confirming this. So, I'll leave "licensor", "licensors", and "licenser". And will add a singular of "licenser".

[This source](https://www.collinsdictionary.com/dictionary/english/licencer) says that "licencer" is GB and I'd like to believe it because it has "c" instead of "s". So, I'm removing "licencers".

Leaving "licensure" because google says that it's NORTH AMERICAN, based on the Oxford Languages ([source](https://www.google.com/search?q=licensure))

Leaving "licenseless" because it's "license" (US) +‎ "-less" ([source](https://en.wiktionary.org/wiki/licenseless))

Replacing "licencing" - present participle of licence (GB) ([source](https://en.wiktionary.org/wiki/licencing)),  with "licensing" - present participle of license (US) ([source](https://en.wiktionary.org/wiki/licensing))

Replacing "licencee(s)" - "licence" (GB) +‎ "-ee" ([source](https://en.wiktionary.org/wiki/licencee)) with "licensee(s)" - "license" (US) +‎ "-ee" ([source](https://en.wiktionary.org/wiki/licensee))

Also, checked all other words containing "licens..." - seems good. And checked "licenc..." words - none found, as expected.

Also, sorted alphabetically (hence, "acceptors" diff).

I ran `yarn && yarn test` locally, it returned `0` exit code.