### PR TITLE
Add some terms to software terms dictionary.

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -202,6 +202,7 @@ const
 convolver
 coord
 coords
+copypaste
 copyq
 coreos
 coroutine
@@ -415,6 +416,7 @@ exprs
 Exps
 extractable
 extractables
+Exts
 fallthrough
 falsy
 favicon
@@ -790,6 +792,7 @@ mdadm
 mdn
 mdx
 MediaWiki
+medicalterms
 member
 memcache
 memcached
@@ -1237,6 +1240,7 @@ stdout
 stmt
 storagectl
 strace
+streetsidesoftware
 stringified
 stringifies
 stringify


### PR DESCRIPTION
Add "copypaste," "Exts," "medicalterms," and "streetsidesoftware."

"Copypaste" is the key Mega-Linter uses for copy-paste detectors.
"Exts" is an abbreviation for "extensions" used by jscpd.
"Medicalterms" is the name of a cspell dictionary.
"Streetsidesoftware" is the name of the organization that houses cspell.