### PR TITLE
Add "mongod" to software terms dictionary.

### DIFF
--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -28,6 +28,7 @@ Google
 HipChat
 Hunspell
 Hunspell
+mongod
 Secretlint
 secretlintignore
 yamllint


### PR DESCRIPTION
"mongod is the primary daemon process for the MongoDB system."
~ https://docs.mongodb.com/manual/reference/program/mongod/