### PR TITLE
Add "MegaLinter" to software tools dictionary.

### DIFF
--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -28,6 +28,7 @@ Google
 HipChat
 Hunspell
 Hunspell
+MegaLinter
 mongod
 Secretlint
 secretlintignore


### PR DESCRIPTION
MegaLinter is a linter aggregator. See https://megalinter.github.io/ for more details.