### PR TITLE
Add `unsecure` to the Dicitonary

### DIFF
--- a/dictionaries/en_US/src/additional_words.txt
+++ b/dictionaries/en_US/src/additional_words.txt
@@ -24,3 +24,7 @@ teleconverter
 tricep
 unintuitive
 unplated
+unsecure
+unsecured
+unsecures
+unsecuring


### PR DESCRIPTION
fix: #778 
`unsecure` is in the British English dictionary, but doesn't appear in the US English dictionary.

Examples of `unsecure`:
> The gate is unsecure.
> He unsecures / unsecured the gate.
> The server is unsecure.