### PR TITLE
chore: use setup-node caching for yarn

### DIFF
--- a/.github/workflows/build-dictionaries.yml
+++ b/.github/workflows/build-dictionaries.yml
@@ -18,6 +18,9 @@ jobs:
         uses: actions/checkout@v2.4.0
         with:
           ref: ${{ env.REF_BRANCH }}
+      - uses: actions/setup-node@v2
+        with:
+          cache: yarn
       - name: Install
         run: |
           yarn

--- a/.github/workflows/cspell-action.yml
+++ b/.github/workflows/cspell-action.yml
@@ -10,5 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
+      - uses: actions/setup-node@v2
+        with:
+          cache: yarn
       - run: yarn
       - uses: streetsidesoftware/cspell-action@v1.3.5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
-      - uses: actions/setup-node@v2.5.0
+      - uses: actions/setup-node@v2
+        with:
+          cache: yarn
       - run: yarn
       - run: yarn run lint-ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2.5.0
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
       - run: yarn
       - run: yarn test
 
@@ -43,8 +44,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2.5.0
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
       - run: yarn
       - run: yarn test

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -23,6 +23,9 @@ jobs:
         uses: actions/checkout@v2.4.0
         with:
           ref: ${{ env.REF_BRANCH }}
+      - uses: actions/setup-node@v2
+        with:
+          cache: yarn
       - name: Update
         run: |
           yarn


### PR DESCRIPTION
- Unpin the version to minimize Dependabot PRs
- Use built-in caching based off off actions/cache