### PR TITLE
fix: add `aria-*` terms to the list.

### DIFF
--- a/dictionaries/html/html.txt
+++ b/dictionaries/html/html.txt
@@ -13,6 +13,7 @@ acE
 acirc
 Acirc
 acronym
+activedescendant
 acute
 acy
 Acy
@@ -144,6 +145,7 @@ asymp
 asympeq
 atilde
 Atilde
+atomic
 attribute
 audio
 auml
@@ -306,6 +308,7 @@ bumpE
 bumpeq
 Bumpeq
 burlywood
+busy
 button
 cacute
 Cacute
@@ -358,6 +361,7 @@ CHcy
 check
 checkbox
 checkboxes
+checked
 checkmark
 chi
 Chi
@@ -390,8 +394,10 @@ clubs
 clubsuit
 code
 col
+colcount
 colgroup
 colheader
+colindex
 colon
 Colon
 colone
@@ -424,6 +430,7 @@ contenteditable
 contentinfo
 contextmenu
 ContourIntegral
+controls
 copf
 Copf
 coprod
@@ -470,6 +477,7 @@ curlyeqsucc
 curlyvee
 curlywedge
 curren
+current
 curvearrowleft
 curvearrowright
 cuvee
@@ -532,6 +540,8 @@ Del
 delta
 Delta
 demptyv
+describedby
+details
 details
 dfisht
 dfn
@@ -624,6 +634,7 @@ drcorn
 drcrop
 dropdown
 dropdowns
+dropeffect
 dscr
 Dscr
 dscy
@@ -722,6 +733,7 @@ equivDD
 eqvparsl
 erarr
 erDot
+errormessage
 escr
 Escr
 esdot
@@ -737,6 +749,7 @@ euro
 excl
 exist
 Exists
+expanded
 expectation
 exponentiale
 ExponentialE
@@ -765,6 +778,7 @@ fjlig
 flat
 fllig
 floralwhite
+flowto
 fltns
 fnof
 focusable
@@ -785,6 +799,7 @@ formnovalidate
 formtarget
 Fouriertrf
 fpartint
+frac
 frac12
 frac13
 frac14
@@ -863,6 +878,7 @@ gold
 goldenrod
 gopf
 Gopf
+grabbed
 grave
 gray
 GreaterEqual
@@ -917,6 +933,7 @@ harr
 hArr
 harrcir
 harrw
+haspopup
 Hat
 hbar
 hcirc
@@ -1083,12 +1100,14 @@ kappa
 Kappa
 kappav
 kbd
+kbdshortcuts
 kcedil
 Kcedil
 kcy
 Kcy
 key
 keygen
+keyshortcuts
 kfr
 Kfr
 kgreen
@@ -1103,6 +1122,7 @@ kscr
 Kscr
 lAarr
 label
+labelledby
 lacute
 Lacute
 laemptyv
@@ -1221,6 +1241,7 @@ LessLess
 lesssim
 LessSlantEqual
 LessTilde
+level
 lfisht
 lfloor
 lfr
@@ -1257,6 +1278,7 @@ list
 listbox
 listitem
 literal
+live
 ljcy
 LJcy
 ll
@@ -1409,6 +1431,7 @@ mlcp
 mldr
 mnplus
 moccasin
+modal
 models
 month
 mopf
@@ -1420,7 +1443,9 @@ Mscr
 mstpos
 mu
 Mu
+multiline
 multimap
+multiselectable
 mumap
 nabla
 nacute
@@ -1801,6 +1826,7 @@ order
 orderof
 ordf
 ordm
+orientation
 origof
 oror
 orslope
@@ -1825,6 +1851,7 @@ OverBar
 OverBrace
 OverBracket
 OverParenthesis
+owns
 p
 pair
 palegoldenrod
@@ -1887,6 +1914,7 @@ polyfill
 polyfills
 popf
 Popf
+posinset
 pound
 powderblue
 pr
@@ -1909,6 +1937,7 @@ precnsim
 precsim
 preprocessor
 presentation
+pressed
 prime
 Prime
 primes
@@ -2009,6 +2038,7 @@ rdquo
 rdquor
 rdsh
 Re
+readonly
 real
 realine
 realpart
@@ -2019,7 +2049,9 @@ red
 refresh
 reg
 REG
+relevant
 repository
+required
 reset
 ReverseElement
 ReverseEquilibrium
@@ -2078,6 +2110,7 @@ rnmid
 roang
 roarr
 robrk
+roledescription
 ropar
 ropf
 Ropf
@@ -2086,8 +2119,11 @@ rosybrown
 rotimes
 RoundImplies
 row
+rowcount
 rowgroup
 rowheader
+rowindex
+rowspan
 rowspan
 royalblue
 rp
@@ -2159,11 +2195,13 @@ seashell
 sect
 section
 select
+selected
 semi
 separator
 seswar
 setminus
 setmn
+setsize
 sext
 sfr
 Sfr
@@ -2227,6 +2265,7 @@ solb
 solbar
 sopf
 Sopf
+sort
 source
 spades
 spadesuit
@@ -2562,6 +2601,10 @@ uuml
 Uuml
 uwangle
 value
+valuemax
+valuemin
+valuenow
+valuetext
 vangrt
 var
 varepsilon


### PR DESCRIPTION
The old compile tool split on `-` before adding words to the list. The new one does not, so words need to be added explicitly.