### PR TITLE
fix: local -> locale

### DIFF
--- a/dictionaries/css/cspell-ext.json
+++ b/dictionaries/css/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "css",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
+            "locale": "*",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["css"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/da_DK/cspell-ext.json
+++ b/dictionaries/da_DK/cspell-ext.json
@@ -24,7 +24,7 @@
             "languageId": "*",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "da,da-DK",
+            "locale": "da,da-DK",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -36,7 +36,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["da-dk"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/dotnet/cspell-ext.json
+++ b/dictionaries/dotnet/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "cs",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
+            "locale": "*",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["dotnet"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/el/cspell-ext.json
+++ b/dictionaries/el/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "*",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "el",
+            "locale": "el",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["el"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/elixir/cspell-ext.json
+++ b/dictionaries/elixir/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "elixir",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
+            "locale": "*",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["elixir"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/en_US/cspell-ext.json
+++ b/dictionaries/en_US/cspell-ext.json
@@ -41,7 +41,7 @@
             ],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["en_us"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": [],
             // Words to always be considered an error
             "flagWords": []

--- a/dictionaries/eo/cspell-ext.json
+++ b/dictionaries/eo/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "*",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "eo",
+            "locale": "eo",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["eo"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/fa_IR/cspell-ext.json
+++ b/dictionaries/fa_IR/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "*",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "fa, fa-IR",
+            "locale": "fa, fa-IR",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["fa-ir"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/fr_FR_90/cspell-ext.json
+++ b/dictionaries/fr_FR_90/cspell-ext.json
@@ -37,7 +37,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["fr-fr-90"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/golang/cspell-ext.json
+++ b/dictionaries/golang/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "go",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
+            "locale": "*",
             // It is common in Go to glue words together.
             "allowCompoundWords": true,
             // By default the whole text of a file is included for spell checking
@@ -37,7 +37,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["golang"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/haskell/cspell-ext.json
+++ b/dictionaries/haskell/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "haskell",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
+            "locale": "*",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -41,7 +41,7 @@
             ],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["haskell"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/he/cspell-ext.json
+++ b/dictionaries/he/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "*",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "he",
+            "locale": "he",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["he"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/hr_HR/cspell-ext.json
+++ b/dictionaries/hr_HR/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "*",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "hr,hr-HR",
+            "locale": "hr,hr-HR",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["hr-hr"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/html/cspell-ext.json
+++ b/dictionaries/html/cspell-ext.json
@@ -76,7 +76,7 @@
             "languageId": "html",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
+            "locale": "*",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -98,7 +98,7 @@
             ],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["html"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/it_IT/cspell-ext.json
+++ b/dictionaries/it_IT/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "*",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "it,it-IT",
+            "locale": "it,it-IT",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["it-it"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/java/cspell-ext.json
+++ b/dictionaries/java/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "java",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
+            "locale": "*",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -40,7 +40,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["java"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/latex/cspell-ext.json
+++ b/dictionaries/latex/cspell-ext.json
@@ -24,7 +24,7 @@
             "languageId": "latex",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
+            "locale": "*",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -57,7 +57,7 @@
             "ignoreRegExpList": ["LaTexMacrosMultiLine", "LaTexMath", "LaTexMacrosFunctionNames"],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["latex"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/lorem-ipsum/cspell-ext.json
+++ b/dictionaries/lorem-ipsum/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "*",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "lorem,lorem-ipsum",
+            "locale": "lorem,lorem-ipsum",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["lorem-ipsum"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/lt_LT/cspell-ext.json
+++ b/dictionaries/lt_LT/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "*",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "lt,lt-LT",
+            "locale": "lt,lt-LT",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["lt-lt"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/lua/cspell-ext.json
+++ b/dictionaries/lua/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "lua",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
+            "locale": "*",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["lua"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/monkeyc/cspell-ext.json
+++ b/dictionaries/monkeyc/cspell-ext.json
@@ -37,7 +37,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["monkeyc"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ],

--- a/dictionaries/nb_NO/cspell-ext.json
+++ b/dictionaries/nb_NO/cspell-ext.json
@@ -37,7 +37,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["nb-no"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/node/cspell-ext.json
+++ b/dictionaries/node/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "javascript,typescript",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
+            "locale": "*",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -36,7 +36,7 @@
             "words": ["yyyymmdd"],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["node"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/npm/cspell-ext.json
+++ b/dictionaries/npm/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "javascript,typescript",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
+            "locale": "*",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["npm"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/php/cspell-ext.json
+++ b/dictionaries/php/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "php",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
+            "locale": "*",
             // This can be removed once cspell-tools are upgraded to @cspell/cspell-tools.
             "words": ["xffffffff"],
             // To exclude patterns, add them to "ignoreRegExpList"
@@ -34,7 +34,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["php"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/pl_PL/cspell-ext.json
+++ b/dictionaries/pl_PL/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "*",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "pl,pl_PL",
+            "locale": "pl,pl_PL",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["pl-pl"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/powershell/cspell-ext.json
+++ b/dictionaries/powershell/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "powershell",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
+            "locale": "*",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -51,7 +51,7 @@
             ],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["powershell"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/pt_PT/cspell-ext.json
+++ b/dictionaries/pt_PT/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "*",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "pt,pt_PT",
+            "locale": "pt,pt_PT",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["pt-pt"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/ru_RU/cspell-ext.json
+++ b/dictionaries/ru_RU/cspell-ext.json
@@ -37,7 +37,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["ru-ru"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/ruby/cspell-ext.json
+++ b/dictionaries/ruby/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "ruby",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
+            "locale": "*",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["ruby"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/rust/cspell-ext.json
+++ b/dictionaries/rust/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "rust",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
+            "locale": "*",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["rust"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/scala/cspell-ext.json
+++ b/dictionaries/scala/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "scala",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
+            "locale": "*",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -40,7 +40,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["scala"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/scientific_terms_US/cspell-ext.json
+++ b/dictionaries/scientific_terms_US/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "*",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
+            "locale": "*",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["scientific-terms-us"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/sv/cspell-ext.json
+++ b/dictionaries/sv/cspell-ext.json
@@ -37,7 +37,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["sv"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/swift/cspell-ext.json
+++ b/dictionaries/swift/cspell-ext.json
@@ -37,7 +37,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["swift"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/tr_TR/cspell-ext.json
+++ b/dictionaries/tr_TR/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "*",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "tr,tr-TR",
+            "locale": "tr,tr-TR",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["tr-tr"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/typescript/cspell-ext.json
+++ b/dictionaries/typescript/cspell-ext.json
@@ -36,7 +36,7 @@
             "languageId": "typescript,javascript,typescriptreact,javascriptreact",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "*",
+            "locale": "*",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -48,7 +48,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["typescript"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/uk_UA/cspell-ext.json
+++ b/dictionaries/uk_UA/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "*",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "uk",
+            "locale": "uk",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["uk-ua"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/vi_VN/cspell-ext.json
+++ b/dictionaries/vi_VN/cspell-ext.json
@@ -23,7 +23,7 @@
             "languageId": "*",
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "local": "vi",
+            "locale": "vi",
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
@@ -35,7 +35,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["vi-vn"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/vue/cspell-ext.json
+++ b/dictionaries/vue/cspell-ext.json
@@ -30,7 +30,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["css", "fonts", "fullstack", "html", "php", "typescript"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/dictionaries/win32/cspell-ext.json
+++ b/dictionaries/win32/cspell-ext.json
@@ -37,7 +37,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["win32"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]

--- a/generator-cspell-dicts/generators/app/templates/cspell-ext.json
+++ b/generator-cspell-dicts/generators/app/templates/cspell-ext.json
@@ -37,7 +37,7 @@
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["<%= packageName %>"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "local" match.
+            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]


### PR DESCRIPTION
Was a warning about this in VSCode, so did a find and replace.

There was another warning about `dictionaryDefinitions` preferring `DictionaryDefinitionPreferred`, but I was less sure how to swap it