### PR TITLE
fix(css): add minmax

### DIFF
--- a/dictionaries/css/css.txt
+++ b/dictionaries/css/css.txt
@@ -555,6 +555,7 @@ middle
 midnightblue
 min
 minimum
+minmax
 mintcream
 misc
 mistyrose


### PR DESCRIPTION
Adds the minmax function from CSS grid

https://developer.mozilla.org/en-US/docs/Web/CSS/minmax()