### PR TITLE
Add markdownlint to npm

### DIFF
--- a/dictionaries/npm/npm.txt
+++ b/dictionaries/npm/npm.txt
@@ -394,6 +394,7 @@ main-bower-files
 markdown
 markdown-it
 markdown-pdf
+markdownlint
 marked
 marky-markdown
 material-ui


### PR DESCRIPTION
This adds the npm markdownlint package to the npm dictionary.