### PR TITLE
Add network dictionaries

### DIFF
--- a/dictionaries/software-terms/src/network-os.txt
+++ b/dictionaries/software-terms/src/network-os.txt
@@ -1,0 +1,13 @@
+arubaos
+asaos
+eos
+ios
+iosxr
+isoxe
+junoos
+junos
+nxos
+routeros
+sros
+tmos
+vyos

--- a/dictionaries/software-terms/src/network-protocols.txt
+++ b/dictionaries/software-terms/src/network-protocols.txt
@@ -1,0 +1,17 @@
+bgp
+dns
+ebgp
+eigrp
+evpn
+ftp
+ibgp
+imap
+ipp
+isis
+ntp
+ospf
+pop3
+rip
+snmp
+ssh
+vxlan


### PR DESCRIPTION
This adds 2 network dictionaries:

1) network protocols, these may overlap with other dictionaries, LMK if that is a problem
2) network os, The operating system acronyms for several network devices from network vendors

Let me know what the next steps are and how I can help