### PR TITLE
Add "CSharpier" and "Sharpier" to software tools

### DIFF
--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -17,6 +17,7 @@ Cloudkick
 CloudStack
 CouchDB
 Crashlytics
+CSharpier
 cspell
 cspellcache
 DigitalOcean
@@ -36,6 +37,7 @@ Podman
 PyCharm
 Secretlint
 secretlintignore
+Sharpier
 snmpd
 snmptrapd
 yamllint


### PR DESCRIPTION
CSharpier is an auto-formatter in the style of Prettier for C#. Since the first two letters are both uppercase, CSpell sometimes tokenizes "Sharpier" as a separate word.