### PR TITLE
Add Atlassian terms to dictionaries

### DIFF
--- a/dictionaries/companies/src/companies.txt
+++ b/dictionaries/companies/src/companies.txt
@@ -139,6 +139,7 @@ Assurant, Inc.
 AstraZeneca
 AT&T
 AT&T Inc.
+Atlassian
 Atmos Energy
 ATVI
 Australia & New Zealand Banking Group
@@ -206,7 +207,6 @@ Bing
 Bio-Rad Laboratories
 Biogen Idec Inc.
 Biogen Inc.
-Bitbucket
 Bitly
 Bjango Pty Ltd
 BKNG

--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -656,8 +656,6 @@ JBoss
 Jekylling
 Jekyllrb
 Jetifier
-jira
-Jira
 JOSM
 journald
 joyent

--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -10,8 +10,10 @@ Apparmor
 Appveyor
 Artifactory
 asdf
+Atlaskit
 Avro
 Bacula
+Bitbucket
 Cloudera
 Cloudkick
 CloudStack
@@ -28,9 +30,11 @@ Gitkraken
 Gitpod
 GMail
 Google
+Halp
 HipChat
 Hunspell
 Hunspell
+Jira
 MegaLinter
 mongod
 Podman
@@ -40,5 +44,7 @@ secretlintignore
 Sharpier
 snmpd
 snmptrapd
+Sourcetree
+Trello
 yamllint
 Zuul


### PR DESCRIPTION
**Added:**
- Atlaskit
- Atlassian
- Halp (could be problematic for misspellings of "help" - LMK if this is allowed)
- Jira
- Sourcetree
- Trello

**Relocated product names to 'software-tools'**
- Bitbucket
- Jira