### PR TITLE
fix: cpp typos

### DIFF
--- a/dictionaries/cpp/cpp.txt
+++ b/dictionaries/cpp/cpp.txt
@@ -64472,7 +64472,6 @@ required_prompts
 requirement
 requirements
 requires
-requirested
 require_action
 require_action_quiet
 require_action_string
@@ -64488,8 +64487,6 @@ require_noerr_string
 require_quiet
 require_string
 requiring
-Requres
-requst
 REQ_BACK_PATTERN
 REQ_BEG_FIELD
 REQ_BEG_LINE


### PR DESCRIPTION
Noticed the "requst" given as a suggestion for a typo "reqest" and traced it back to this dictionary. Saw a few around it that also looks like typos