### PR TITLE
feat!: Remove `allowCompoundWords: true`

### DIFF
--- a/dictionaries/cpp/cspell-ext.json
+++ b/dictionaries/cpp/cspell-ext.json
@@ -22,7 +22,6 @@
             // VSCode languageId. i.e. typescript, java, go, cpp, javascript, markdown, latex
             // * will match against any file type.
             "languageId": "c,cpp",
-            "allowCompoundWords": true,
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
             "locale": "*",

--- a/dictionaries/cpp/cspell.json
+++ b/dictionaries/cpp/cspell.json
@@ -1,26 +1,9 @@
 {
-    "files": [
-        "**/*.{md,txt}"
-    ],
-    "ignorePaths": [
-        "/cpp.txt"
-    ],
-    "dictionaries": [
-        "cpp"
-    ],
-    "import": [
-        "./cspell-ext.json"
-    ],
-    "ignoreWords": [
-        "aaaabbbb",
-        "ffffeeee",
-        "xffff",
-        "yyyy",
-        "yyyymm",
-        "yyyymmdd",
-        "yyyymmddhhmmss",
-        "yyyymmddhhmmssz"
-    ],
+    "files": ["**/*.{md,txt}"],
+    "ignorePaths": ["/cpp.txt"],
+    "dictionaries": ["cpp"],
+    "import": ["./cspell-ext.json"],
+    "ignoreWords": ["aaaabbbb", "ffffeeee", "xffff", "yyyy", "yyyymm", "yyyymmdd", "yyyymmddhhmmss", "yyyymmddhhmmssz"],
     "overrides": [
         {
             "filename": "cpp.txt",

--- a/dictionaries/csharp/cspell-ext.json
+++ b/dictionaries/csharp/cspell-ext.json
@@ -18,7 +18,6 @@
             "description": "These are the language settings for C#",
             "includeRegExpList": [],
             "ignoreRegExpList": [],
-            "allowCompoundWords": true,
             "patterns": [
                 {
                     "name": "string",

--- a/dictionaries/csharp/cspell.json
+++ b/dictionaries/csharp/cspell.json
@@ -1,12 +1,5 @@
 {
-    "files": [
-        "**/*.{md,txt}",
-        "**/*.cs"
-    ],
-    "dictionaries": [
-        "csharp"
-    ],
-    "import": [
-        "./cspell-ext.json"
-    ]
+    "files": ["**/*.{md,txt}", "**/*.cs"],
+    "dictionaries": ["csharp"],
+    "import": ["./cspell-ext.json"]
 }

--- a/dictionaries/golang/cspell-ext.json
+++ b/dictionaries/golang/cspell-ext.json
@@ -25,8 +25,6 @@
             // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
             "locale": "*",
-            // It is common in Go to glue words together.
-            "allowCompoundWords": true,
             // By default the whole text of a file is included for spell checking
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],

--- a/dictionaries/golang/cspell.json
+++ b/dictionaries/golang/cspell.json
@@ -1,16 +1,6 @@
 {
-    "files": [
-        "**/*.{md,txt}"
-    ],
-    "dictionaries": [
-        "golang"
-    ],
-    "import": [
-        "./cspell-ext.json"
-    ],
-    "ignoreWords": [
-        "Alek",
-        "Alexey",
-        "Palazhchenko"
-    ]
+    "files": ["**/*.{md,txt}"],
+    "dictionaries": ["golang"],
+    "import": ["./cspell-ext.json"],
+    "ignoreWords": ["Alek", "Alexey", "Palazhchenko"]
 }

--- a/dictionaries/python/cspell-ext.json
+++ b/dictionaries/python/cspell-ext.json
@@ -23,7 +23,6 @@
             // Matching Language
             "languageId": "python",
             // Apply settings
-            "allowCompoundWords": true,
             "dictionaries": ["python"],
             "ignoreRegExpList": ["ignore_string_literal_prefix"],
             "patterns": [

--- a/dictionaries/python/python.txt
+++ b/dictionaries/python/python.txt
@@ -326,6 +326,7 @@ fcntl
 fdopen
 file_util
 filecmp
+filedata
 filedialog
 FileExistsError
 fileinput
@@ -370,6 +371,8 @@ getattr
 getctime
 getcwd
 getenv
+getheader
+getheaders
 getopt
 getpass
 gettext
@@ -453,6 +456,7 @@ islower
 ismount
 isnan
 isnumeric
+isoformat
 isort
 isprintable
 isqrt
@@ -525,6 +529,7 @@ mimetypes
 min
 minidom
 mkdir
+mkstemp
 mmap
 mock
 model
@@ -560,6 +565,7 @@ numpy
 object
 oct
 open
+openapi
 operator
 optparse
 or
@@ -766,6 +772,7 @@ textpad
 textwrap
 threading
 threading_helper
+threadpool
 tigetnum
 time
 timeit


### PR DESCRIPTION
BREAKING CHANGE

Do not set `allowCompoundWords: true` for
- cpp, c
- csharp
- go
- python

To add it back, use:

```json
    "languageSettings": [
        {
            "languageId": "c,cpp,csharp,go,python",
            "allowCompoundWords": true
        }
    ]
```