### PR TITLE
Add HTTP Accept-Encoding values to full stack dict

### DIFF
--- a/dictionaries/fullstack/fullstack.txt
+++ b/dictionaries/fullstack/fullstack.txt
@@ -23,6 +23,7 @@ autoprefixer
 autosize
 baseref
 bigint
+br
 bugfix
 bugfixes
 buttonface
@@ -52,6 +53,7 @@ codemirror
 codespan
 collapsable
 compat
+compress
 concat
 cond
 conda
@@ -78,6 +80,7 @@ deallocating
 deallocation
 decltype
 delim
+deflate
 deregister
 deserialize
 devkit
@@ -129,6 +132,7 @@ grayscale
 graytext
 gtag
 guid
+gzip
 hammerjs
 hexcolor
 hfile
@@ -140,6 +144,7 @@ htmleditor
 htmlembedded
 htmlmixed
 icomoon
+identity
 ifdef
 ifndef
 imap
@@ -428,3 +433,4 @@ xmls
 xquery
 xvzf
 xxhash
+zstd


### PR DESCRIPTION
Add "br," "compress," "deflate," "gzip," "identity," and "zstd."