### PR TITLE
Add "enumtype" and "typegoose" to npm dictionary

### DIFF
--- a/dictionaries/npm/npm.txt
+++ b/dictionaries/npm/npm.txt
@@ -125,6 +125,7 @@ email-templates
 emailjs
 ember-cli
 emmet
+enumtype
 errorhandler
 es6-promise
 eslint
@@ -620,6 +621,7 @@ tsd
 tslint
 twit
 twitter
+typegoose
 typescript
 typescript-formatter
 typings


### PR DESCRIPTION
"enumtype" is a type from the popular ts-interface-checker package.
"typegoose" is the name of a popular package.