### PR TITLE
feat: Make sure French is case and accent sensitive by default.

### DIFF
--- a/dictionaries/fr_FR/cspell-ext.json
+++ b/dictionaries/fr_FR/cspell-ext.json
@@ -14,6 +14,7 @@
         {
             "languageId": "*",
             "locale": "fr,fr_FR",
+            "caseSensitive": true,
             "includeRegExpList": [],
             "patterns": [],
             "dictionaries": ["fr-fr"],

--- a/dictionaries/fr_FR_90/cspell-ext.json
+++ b/dictionaries/fr_FR_90/cspell-ext.json
@@ -1,11 +1,9 @@
-// cSpell Settings
 {
     "id": "fr-fr-90",
     "name": "Français Réforme 1990",
     "version": "0.2",
     "description": "Français Réforme 1990 dictionary for cspell.",
     "readonly": true,
-    // List of dictionary files to add to the global list of dictionaries
     "dictionaryDefinitions": [
         {
             "name": "fr-fr-90",
@@ -13,31 +11,15 @@
             "description": "Français Réforme 1990 dictionary for cspell."
         }
     ],
-    // Dictionaries to always be used.
-    // Generally left empty
-    "dictionaries": [],
-    // Language Rules to apply to matching files.
-    // Files are matched on `languageId` and `local`
     "languageSettings": [
         {
-            // VSCode languageId. i.e. typescript, java, go, cpp, javascript, markdown, latex
-            // * will match against any file type.
             "languageId": "*",
-            // Language local. i.e. en-US, de-AT, or ru. * will match all locals.
-            // Multiple locals can be specified like: "en, en-US" to match both English and English US.
             "locale": "fr,fr-fr,fr-90",
-            // By default the whole text of a file is included for spell checking
-            // Adding patterns to the "includeRegExpList" to only include matching patterns
+            "caseSensitive": true,
             "includeRegExpList": [],
-            // To exclude patterns, add them to "ignoreRegExpList"
             "ignoreRegExpList": [],
-            // regex patterns than can be used with ignoreRegExpList or includeRegExpList
-            // Example: "pattern": [{ "name": "mdash", "pattern": "&mdash;" }]
-            // This could be included in "ignoreRegExpList": ["mdash"]
             "patterns": [],
-            // List of dictionaries to enable by name in `dictionaryDefinitions`
             "dictionaries": ["fr-fr-90"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }
     ]


### PR DESCRIPTION
**Note:** this is a semi breaking change for code.

To turn off cases sensitivity for a file type:

**`cspell.json`** turn off for JavaScript
```json
{
    "languageSettings": [
        {
            "languageId": "javascript",
            "locale": "fr,fr_FR",
            "caseSensitive": false
        }
    ]
}
```
