### PR TITLE
Add "fullmatch" to Python dictionary

### DIFF
--- a/dictionaries/python/src/python/python.txt
+++ b/dictionaries/python/src/python/python.txt
@@ -358,6 +358,7 @@ fsdecode
 fsencode
 fsum
 ftplib
+fullmatch
 functools
 futures
 FutureWarning


### PR DESCRIPTION
This is a function in the `re` module.