### PR TITLE
Add some popular npm packages to npm dictionary

### DIFF
--- a/dictionaries/npm/npm.txt
+++ b/dictionaries/npm/npm.txt
@@ -353,6 +353,7 @@ jotai
 jquery
 js-beautify
 js-yaml
+jscpd
 jscs
 jsdoc
 jsdom
@@ -371,6 +372,7 @@ knex
 knox
 koa
 koa-router
+kucherenko
 kue
 lab
 lazy.js
@@ -634,6 +636,7 @@ useragent
 uuid
 validator
 vasync
+vercel
 verror
 vhost
 vinyl


### PR DESCRIPTION
Add "jscpd," "kucherenko," and "vercel," which are the names of some popular npm packages or their GitHub organization.