### PR TITLE
Add "testdouble" to npm dictionary

### DIFF
--- a/dictionaries/npm/npm.txt
+++ b/dictionaries/npm/npm.txt
@@ -619,6 +619,7 @@ tap
 tape
 tar
 terminal-menu
+testdouble
 three
 through
 through2


### PR DESCRIPTION
testdouble is a popular test double library.