### PR TITLE
fix: adjust `java-member-function` pattern

### DIFF
--- a/dictionaries/java/cspell-ext.json
+++ b/dictionaries/java/cspell-ext.json
@@ -19,7 +19,7 @@
         {
             "name": "java-member-function",
             "description": "Ignore member functions etc, these are checked by the compiler.",
-            "pattern": "/\\.\\w+(?=\\()/g"
+            "pattern": "/(\\.\\w+)+(?=\\()/g"
         }
     ],
     "languageSettings": [


### PR DESCRIPTION
Adjust the pattern to match more of the expression.

Given: `System.out.print(`
Old: `.print`
New: `.out.print`