### PR TITLE
fix(html): add preconnect

### DIFF
--- a/dictionaries/html/html.txt
+++ b/dictionaries/html/html.txt
@@ -1934,6 +1934,7 @@ preceq
 precnapprox
 precneqq
 precnsim
+preconnect
 precsim
 preprocessor
 presentation


### PR DESCRIPTION
Adds the `preconnect` link type

https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preconnect