### PR TITLE
[Rust] Add "dedup", a method name in std::vec::Vec

### DIFF
--- a/dictionaries/rust/rust.txt
+++ b/dictionaries/rust/rust.txt
@@ -20,6 +20,7 @@ const
 continue
 crate
 deallocate
+dedup
 Deref
 DerefMut
 deserialize


### PR DESCRIPTION
Hi, thank you for publishing great tools.

It turns out that "dedup", a name of the de-duplication method in std::vec::Vec, is treated as an error in spell checking. This PR fixes this problem by adding "dedup" to the dictionary.

Ref: https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.dedup