### PR TITLE
fix: Update `'` parsing in Haskell

### DIFF
--- a/dictionaries/haskell/cspell-ext.json
+++ b/dictionaries/haskell/cspell-ext.json
@@ -36,7 +36,7 @@
             "patterns": [
                 {
                     "name": "separators",
-                    "pattern": "/(?<!n(?='t\\b))(?<!\\w(?='s\\b))(?<!d(?='ve\\b))(?<!\\w(?='d\\b))(?<!\\w(?='re\\b))'/gi",
+                    "pattern": "/(?<!n(?='t\\b))(?<!\\w(?='s\\b))(?<!d(?='ve\\b))(?<!\\w(?='d\\b))(?<!\\w(?='re\\b))'(?!(ll|ve|tis|twas|cause|n't|(?<=\\bma')am|((?<=\\bI')m|((?<=d')y))|((?<=\\by')alls?))\\b)/gi",
                     "description": "Ignore single quote when it is not a contraction."
                 }
             ],

--- a/dictionaries/haskell/cspell.json
+++ b/dictionaries/haskell/cspell.json
@@ -1,12 +1,6 @@
 {
-    "files": [
-        "**/*.{md,txt}"
-    ],
-    "dictionaries": [
-        "haskell"
-    ],
-    "import": [
-        "./cspell-ext.json"
-    ],
+    "files": ["**/*.{md,txt,hs}"],
+    "dictionaries": ["haskell"],
+    "import": ["./cspell-ext.json"],
     "ignoreWords": []
 }

--- a/dictionaries/haskell/samples/fib.hs
+++ b/dictionaries/haskell/samples/fib.hs
@@ -1,0 +1,22 @@
+import Control.Parallel
+
+main = a `par` b `par` c `pseq` print (a + b + c)
+    where
+        a = ack 3 10
+        b = fac 42
+        c = fib 34
+
+fac 0 = 1
+fac n = n * fac (n-1)
+
+ack 0 n = n+1
+ack m 0 = ack (m-1) 1
+ack m n = ack (m-1) (ack m (n-1))
+
+fib 0 = 0
+fib 1 = 1
+fib n = fib (n-1) + fib (n-2)
+
+this'is'a'long'variable'name = "doesn't"
+
+-- cspell:words ack pseq


### PR DESCRIPTION
Support more contractions: https://github.com/streetsidesoftware/vscode-spell-checker/issues/707#issuecomment-1172980816