### PR TITLE
fix: add `negatable` to en-US

### DIFF
--- a/dictionaries/en_US/src/additional_words.txt
+++ b/dictionaries/en_US/src/additional_words.txt
@@ -39,6 +39,7 @@ iPads
 Kyiv
 multiline
 naïve
+negatable
 Orléans
 prepend
 reauthenticate


### PR DESCRIPTION
https://en.wiktionary.org/wiki/negatable