### PR TITLE
feat: add heif types

### DIFF
--- a/dictionaries/cpp/src/cpp.txt
+++ b/dictionaries/cpp/src/cpp.txt
@@ -8063,6 +8063,8 @@ avail_out
 avail_reports
 avalue
 AVcCDdvZ
+avci
+avcs
 Avdeev
 avenrun
 Avenue
@@ -8076,6 +8078,8 @@ avg
 avgs
 avg_id_len
 avg_obj_size
+avif
+avifs
 AVL
 avn
 avoid
@@ -29729,6 +29733,10 @@ hebrevc
 Hedbor
 HedRARkbkGe
 HEi
+heic
+heics
+heif
+heifs
 height
 heights
 heightXXX
@@ -29764,6 +29772,7 @@ Hesiod
 Hess
 heuristic
 heuristics
+hevc
 Hew
 Hewlett
 hex

--- a/dictionaries/filetypes/filetypes.txt
+++ b/dictionaries/filetypes/filetypes.txt
@@ -17,7 +17,11 @@ ascx
 asp
 aspx
 atom
+avci
+avcs
 avi
+avif
+avifs
 axml
 babelrc
 bas
@@ -114,6 +118,11 @@ handlebars
 hant
 haskell
 hbs
+heic
+heics
+heif
+heifs
+hevc
 hh
 hpp
 htm


### PR DESCRIPTION
Adds HEIF file types
https://en.wikipedia.org/wiki/High_Efficiency_Video_Coding

I wasn't exactly sure which dictionary to add these to, please let me know if they should be moved to another dict.