### PR TITLE
Add linuxserver and baseimage to dictionaries

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -91,6 +91,7 @@ backtick
 backtrace
 bar
 basedir
+baseimage
 basename
 baseurl
 bashrc

--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -35,6 +35,7 @@ HipChat
 Hunspell
 Hunspell
 Jira
+linuxserver
 MegaLinter
 mongod
 Octicons


### PR DESCRIPTION
Refer to LinuxServer's [Alpine Docker image](https://github.com/linuxserver/docker-baseimage-alpine/pkgs/container/baseimage-alpine), for example.