### PR TITLE
add the plural "divs" to en and gb dicts

### DIFF
--- a/dictionaries/en_GB/src/additional_words.txt
+++ b/dictionaries/en_GB/src/additional_words.txt
@@ -5,6 +5,7 @@ bicep
 Christoph
 conformant
 COVID
+divs
 dropshipper
 dropshippers
 dropshipping

--- a/dictionaries/en_US/src/additional_words.txt
+++ b/dictionaries/en_US/src/additional_words.txt
@@ -24,6 +24,7 @@ curbside
 déjà
 draggable
 discretized
+divs
 drive-thru
 drive through
 drive-through


### PR DESCRIPTION
In paid Grammarly, both singular `div` and plural `divs` are recognised OK:
![Screenshot 2022-07-20 at 08 54 32](https://user-images.githubusercontent.com/8344688/179932129-ae8695a7-d36c-48fd-a461-139d44157082.png)

but not on cspell:
![Screenshot 2022-07-20 at 08 54 49](https://user-images.githubusercontent.com/8344688/179932220-a1b5798b-403f-41b9-a293-899e3279f093.png)

Let's fix this!
