### PR TITLE
fix: Add backtick to English dictionary

### DIFF
--- a/dictionaries/en_US/src/additional_words.txt
+++ b/dictionaries/en_US/src/additional_words.txt
@@ -13,6 +13,8 @@
 # There should be one entry per line.
 
 Alpha Centauri
+backtick
+backticks
 bicep
 Centauri # can be removed once split works as expected on merged word lists.
 Christoph


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: `en_US`

## Description

Add `backtick` and `backticks`.

## References

- [Backtick - Wikipedia](https://en.wikipedia.org/wiki/Backtick)

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
