### PR TITLE
fix: fix url for danish spell checker

### DIFF
--- a/dictionaries/da_DK/README.md
+++ b/dictionaries/da_DK/README.md
@@ -2,7 +2,7 @@
 
 Danish dictionary for cspell.
 
-This is a pre-built dictionary, based on [stavekontrolden.dk](http://www.stavekontrolden.dk/main/top/index.php), for use with cspell.
+This is a pre-built dictionary, based on [stavekontrolden.dk](https://www.stavekontrolden.dk), for use with cspell.
 
 ## Installation
 


### PR DESCRIPTION
<!---
name: fix url for danish spell checker home page
about: the url for danish spell checker is not exist any more 
title: 'fix: '
labels: danish, da
--->

# Add/Fix Dictionary
danish dic
Dictionary: danish

## Description

this url is not exist any more [http://www.stavekontrolden.dk/main/top/index.php)](http://www.stavekontrolden.dk/main/top/index.php) , you can check it here : 
https://web.archive.org/web/20190913023653/http://www.stavekontrolden.dk/main/top/index.php , the new fix always shows the home page of that website.
