### PR TITLE
fix: Add "chainable" to the software terms

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -187,6 +187,7 @@ CentOS
 cfml
 cgroup
 chai
+chainable
 changelog
 changelogs
 changeset


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: software terms

## Description

Add the word "chainable". As in "The methods on this class all return `this`, this means they are chainable". 

I was tempted to add it to en-gb and en-us but after a quick Google the only website I can find it on is Wiktionary.

## References

### Found here

https://en.wiktionary.org/wiki/chainable

### Not found here

https://www.thefreedictionary.com/chainable
https://dictionary.cambridge.org/spellcheck/english/?q=chainable
https://www.merriam-webster.com/dictionary/chainable
https://www.dictionary.com/misspelling?term=chainable

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
