### PR TITLE
fix: add back `ldap` to software terms

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -748,6 +748,7 @@ launchd
 lbound
 lbrace
 lbracket
+ldap
 lemma
 lemmas
 lemmata


### PR DESCRIPTION
- LDAP is too common of a term is software security discussions to be only included in the network protocol dictionaries.
- Adjusts #1397
- Detected during dictionary update of CSpell: https://github.com/streetsidesoftware/cspell/pull/3495

## References

- [Lightweight Directory Access Protocol - Wikipedia](https://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol)

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
