### PR TITLE
fix: Red Hat is actually two words

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -1145,7 +1145,6 @@ Recv
 Reddit
 Reddit's
 redeclare
-RedHat
 redirectable
 Redis
 reduce


### PR DESCRIPTION
This is a common typo the way it is here. See https://www.redhat.com

Signed-off-by: Tim Smith <tsmith84@gmail.com>