### PR TITLE
fix: Add `cmake` to software tools

### DIFF
--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -32,6 +32,7 @@ CircleCI
 Cloudera
 Cloudkick
 CloudStack
+cmake
 CouchDB
 Crashlytics
 cron


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: software-terms

## Description

`cmake` is a popular tool.

## References

- https://cmake.org

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
