### PR TITLE
fix: Remove typos from software terms

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -1159,7 +1159,7 @@ resizable
 resize
 resized
 resizing
-resoluton
+resolution
 restructuredtext
 rethrow
 rethrowable

--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -573,7 +573,7 @@ hoist
 homedir
 homepage
 homogenous
-homogenously
+homogeneously
 host
 hostname
 hotfix

--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -841,7 +841,7 @@ menubars
 menuitem
 menuitems
 merb
-MERCHANTABLITY
+MERCHANTABILITY
 meta
 metadata
 micromatch

--- a/dictionaries/typescript/typescript.txt
+++ b/dictionaries/typescript/typescript.txt
@@ -2680,7 +2680,7 @@ reset
 resident
 resize
 resolution
-resoluton
+resolution
 resolve
 resolved
 resolvedOptions


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary:
* dictionaries/software-terms/src/software-terms.txt
* dictionaries/typescript/typescript.txt (happy to drop this)

## Description

Remove three entries from `software-terms.txt`

## References



## Checklist

- [ ] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
