### PR TITLE
fix: Add "captchas" to software terms

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -177,6 +177,7 @@ camelizes
 camelizing
 Camunda
 captcha
+captchas
 Caskroom
 CDATA
 cfml


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: software terms

## Description

Adds "captchas" (plural of "captcha")

## References

N/A

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
