### PR TITLE
feat!: Support Umlaut alternatives

### DIFF
--- a/dictionaries/de_DE/cspell-ext.json
+++ b/dictionaries/de_DE/cspell-ext.json
@@ -8,7 +8,34 @@
         {
             "name": "de-de",
             "path": "./de_DE.trie.gz",
-            "description": "German (de-DE) Dictionary."
+            "description": "German (de-DE) Dictionary.",
+            "repMap": [
+                ["ae", "ä"],
+                ["oe", "ö"],
+                ["ue", "ü"],
+                ["Ae", "Ä"],
+                ["Oe", "Ö"],
+                ["Ue", "Ü"],
+                ["ss", "ß"]
+            ],
+            "dictionaryInformation": {
+                "locale": "de_DE",
+                "alphabet": "a-zA-ZäüößáéêàâñÄÜÖÉ",
+                "suggestionEditCosts": [
+                    {
+                        "map": "(ae)ä|(oe)ö|(ue)ü(Ae)Ä|(Oe)Ö|(Ue)Ü|(ss)ß",
+                        "replace": 0
+                    },
+                    {
+                        "map": "eéèëê|aáà|iíìïî|oóòöô|uüúùû|(ij)(ĳ)(IJ)(Ĳ)",
+                        "replace": 1
+                    },
+                    {
+                        "map": "(ah)a|(ch)k|(ee)e|(eh)e|(ph)f|(th)t|dt|i(ie)|o(oh)|r(rh)|s(ss)|t(th)",
+                        "replace": 50
+                    }
+                ]
+            }
         }
     ],
     "dictionaries": [],

--- a/dictionaries/de_DE/cspell.json
+++ b/dictionaries/de_DE/cspell.json
@@ -6,6 +6,7 @@
     "import": [
         "./cspell-ext.json"
     ],
+    "ignorePaths": ["cspell-ext.json", "*.trie", "/src/**"],
     "ignoreWords": [
         "frami",
         "Huggenberger",

--- a/dictionaries/de_DE/samples/alternate_spelling.md
+++ b/dictionaries/de_DE/samples/alternate_spelling.md
@@ -1,0 +1,12 @@
+# Umlaut
+
+- https://github.com/streetsidesoftware/cspell/issues/3590
+- https://github.com/streetsidesoftware/cspell/issues/3592
+- https://github.com/streetsidesoftware/vscode-spell-checker/issues/2066
+- https://github.com/streetsidesoftware/cspell-dicts/issues/1176
+
+Strasse
+Straße
+
+Übung
+Uebung


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: de_DE

## Description

fixes #1176

BREAKING: This change requires CSpell 6.12.0 or higher.

## References

- https://github.com/streetsidesoftware/cspell/issues/3590
- https://github.com/streetsidesoftware/cspell/issues/3592
- https://github.com/streetsidesoftware/vscode-spell-checker/issues/2066
- https://github.com/streetsidesoftware/cspell-dicts/issues/1176

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
