### PR TITLE
fix: Add "Checkov" to the software tools dict

### DIFF
--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -23,6 +23,7 @@ bundler
 busybox
 bzip
 CentOS
+Checkov
 ChefSpec
 chmod
 chown


### PR DESCRIPTION
See [Checkov's documentation](https://www.checkov.io/1.Welcome/Quick%20Start.html).
