### PR TITLE
feat!: Drop Support for CSpell 5.

### DIFF
--- a/dictionaries/ada/README.md
+++ b/dictionaries/ada/README.md
@@ -6,6 +6,13 @@ This is a pre-built dictionary for use with cspell.
 
 Supports Ada keywords.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/aws/README.md
+++ b/dictionaries/aws/README.md
@@ -4,6 +4,13 @@ AWS terms dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/bash/README.md
+++ b/dictionaries/bash/README.md
@@ -4,6 +4,13 @@ Bash dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/clojure/README.md
+++ b/dictionaries/clojure/README.md
@@ -4,6 +4,13 @@ Clojure dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/companies/README.md
+++ b/dictionaries/companies/README.md
@@ -4,6 +4,13 @@ Company names dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/cpp/README.md
+++ b/dictionaries/cpp/README.md
@@ -4,6 +4,13 @@ C/C++ Dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/cryptocurrencies/README.md
+++ b/dictionaries/cryptocurrencies/README.md
@@ -4,6 +4,13 @@ Cryptocurrencies dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/csharp/README.md
+++ b/dictionaries/csharp/README.md
@@ -4,6 +4,13 @@ Csharp dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/css/README.md
+++ b/dictionaries/css/README.md
@@ -4,6 +4,13 @@ Css dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/dart/README.md
+++ b/dictionaries/dart/README.md
@@ -4,6 +4,13 @@ Dart dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/django/README.md
+++ b/dictionaries/django/README.md
@@ -4,6 +4,13 @@ Django dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/dotnet/README.md
+++ b/dictionaries/dotnet/README.md
@@ -4,6 +4,13 @@
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/elixir/README.md
+++ b/dictionaries/elixir/README.md
@@ -4,6 +4,13 @@ Elixir dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/en_US/README.md
+++ b/dictionaries/en_US/README.md
@@ -8,6 +8,13 @@ This is a pre-built dictionary for use with cspell.
 
 This dictionary comes pre-installed with cspell. It should not be necessary to add it.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/filetypes/README.md
+++ b/dictionaries/filetypes/README.md
@@ -4,6 +4,13 @@ Filetypes dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/fonts/README.md
+++ b/dictionaries/fonts/README.md
@@ -4,6 +4,13 @@ Font names dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/fullstack/README.md
+++ b/dictionaries/fullstack/README.md
@@ -4,6 +4,13 @@ Daily used developers words dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/git/README.md
+++ b/dictionaries/git/README.md
@@ -2,6 +2,13 @@
 
 Configuration for spell checking Git Commit messages.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/golang/README.md
+++ b/dictionaries/golang/README.md
@@ -8,6 +8,13 @@ Supports keywords and built-in library names up to Go 1.12.
 
 This dictionary is included by default in cSpell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/haskell/README.md
+++ b/dictionaries/haskell/README.md
@@ -4,6 +4,13 @@ Haskell dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/html-symbol-entities/README.md
+++ b/dictionaries/html-symbol-entities/README.md
@@ -6,6 +6,13 @@ This is a pre-built dictionary for use with cspell.
 
 This addon dictionary adds HTML symbol entities like: `&mdash;`, `&laquo;`, and `&gtrarr;` to the spell checker for `html` and `markdown` files.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/html/README.md
+++ b/dictionaries/html/README.md
@@ -4,6 +4,13 @@ Html dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/java/README.md
+++ b/dictionaries/java/README.md
@@ -4,6 +4,13 @@ Java dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/latex/README.md
+++ b/dictionaries/latex/README.md
@@ -4,6 +4,13 @@ LaTeX cspell dictionary
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/lorem-ipsum/README.md
+++ b/dictionaries/lorem-ipsum/README.md
@@ -4,6 +4,13 @@ Lorem-ipsum dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/lua/README.md
+++ b/dictionaries/lua/README.md
@@ -4,6 +4,13 @@ Lua dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/markdown/README.md
+++ b/dictionaries/markdown/README.md
@@ -4,6 +4,13 @@ Markdown dictionary for cspell.
 
 This is a pre-built dictionary for use with CSpell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to CSpell global settings.

--- a/dictionaries/medicalterms/README.md
+++ b/dictionaries/medicalterms/README.md
@@ -4,6 +4,13 @@ Medical Terms dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/mnemonics/README.md
+++ b/dictionaries/mnemonics/README.md
@@ -4,6 +4,13 @@ i86 Mnemonics dictionary for cspell
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/node/README.md
+++ b/dictionaries/node/README.md
@@ -4,6 +4,13 @@ Node.js dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/npm/README.md
+++ b/dictionaries/npm/README.md
@@ -4,6 +4,13 @@ NPM dictionary for CSpell.
 
 This is a pre-built dictionary for use with CSpell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to CSpell global settings.

--- a/dictionaries/php/README.md
+++ b/dictionaries/php/README.md
@@ -4,6 +4,13 @@ Php dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/powershell/README.md
+++ b/dictionaries/powershell/README.md
@@ -4,6 +4,13 @@ PowerShell Keyword Dictionary
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/public-licenses/README.md
+++ b/dictionaries/public-licenses/README.md
@@ -4,6 +4,13 @@ Common Public Licenses dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/python/README.md
+++ b/dictionaries/python/README.md
@@ -4,6 +4,13 @@ Python dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/r/README.md
+++ b/dictionaries/r/README.md
@@ -4,6 +4,13 @@ R dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/ruby/README.md
+++ b/dictionaries/ruby/README.md
@@ -4,6 +4,13 @@ For ruby and ruby on rails
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/rust/README.md
+++ b/dictionaries/rust/README.md
@@ -4,6 +4,13 @@ Rust dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/scala/README.md
+++ b/dictionaries/scala/README.md
@@ -4,6 +4,13 @@ Scala dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/software-terms/README.md
+++ b/dictionaries/software-terms/README.md
@@ -4,6 +4,13 @@ Software terms dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/sql/README.md
+++ b/dictionaries/sql/README.md
@@ -4,6 +4,13 @@ SQL dictionary for CSpell.
 
 This is a pre-built dictionary for use with CSpell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to CSpell global settings.

--- a/dictionaries/swift/README.md
+++ b/dictionaries/swift/README.md
@@ -4,6 +4,13 @@ Swift dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/typescript/README.md
+++ b/dictionaries/typescript/README.md
@@ -4,6 +4,13 @@ TypeScript and JavaScript dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/vue/README.md
+++ b/dictionaries/vue/README.md
@@ -2,6 +2,13 @@
 
 Configuration bundle for VUE files.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.

--- a/dictionaries/win32/README.md
+++ b/dictionaries/win32/README.md
@@ -4,6 +4,13 @@ Win32 dictionary for cspell.
 
 This is a pre-built dictionary for use with cspell.
 
+## Requirements
+
+| Tool                                                                                                                                 | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [cspell](https://github.com/streetsidesoftware/cspell)                                                                               | `>= 6`  |
+| [Code Spell Checker - Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | `>= 2`  |
+
 ## Installation
 
 Global Install and add to cspell global settings.


### PR DESCRIPTION
Active Support for CSpell 5 has stopped.

The idea is to bump the major version of the dictionaries to prevent breaking CSpell 5 installations when changes to the dictionaries that depend upon CSpell 6 are made.

