### PR TITLE
fix: add pixelated and pixellated to software-terms

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -1010,6 +1010,8 @@ permalink
 permalinks
 personalizations
 pixel
+pixelated
+pixellated
 plaintext
 plist
 plugin


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: software-terms

## Description

Adds pixelated to software-terms. Also adds the British spelling (pixellated) 

## References

- https://en.wikipedia.org/wiki/Pixelation
- https://www.dictionary.com/browse/pixelated
- https://www.thefreedictionary.com/pixelated
- https://dictionary.cambridge.org/us/dictionary/english/pixelated

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
