### PR TITLE
fix: add `deref` - dereference

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -347,6 +347,7 @@ dequeue
 dequeued
 dequeueing
 dequeuing
+deref
 dereference
 dereferenced
 dereferences


### PR DESCRIPTION

<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: software-terms

## Description

`deref` is a common shortening of `dereference` in code.

## References

- [WeakRef.prototype.deref() - JavaScript | MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef/deref)

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
