### PR TITLE
fix: Add to Aruban en_gb

### DIFF
--- a/dictionaries/en_GB/src/additional_words.txt
+++ b/dictionaries/en_GB/src/additional_words.txt
@@ -18,3 +18,4 @@ reauthenticate
 tricep
 unintuitive
 unplated
+Aruban

--- a/dictionaries/en_GB/src/additional_words.txt
+++ b/dictionaries/en_GB/src/additional_words.txt
@@ -1,5 +1,7 @@
 # Add words below
 Alpha Centauri
+Aruban
+Arubans
 amphitheatre
 bicep
 Christoph
@@ -18,4 +20,3 @@ reauthenticate
 tricep
 unintuitive
 unplated
-Aruban


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: en_gb

## Description

Add the word Aruban

## References

- [Wikipedia Article on Aruba](https://en.wikipedia.org/wiki/Aruba)

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
