### PR TITLE
fix: Adjust the CSS dictionary to be backwards compatible.

### DIFF
--- a/dictionaries/css/dict/css.txt
+++ b/dictionaries/css/dict/css.txt
@@ -17,21 +17,8 @@
 -moz-window-titlebar-maximized
 3dlight
 Apple
-Basic
 EN
-Extended
 Hz
-Legibility
-PUBLIC
-Painted
-PropertyList
-Quality
-RRGGBB
-RRGGBBAA
-Speed
-TR
-UTF
-Z
 abbr
 abegede
 absolute
@@ -72,6 +59,7 @@ arithmetic
 armenian
 around
 array
+arrow
 article
 as
 ascii
@@ -89,6 +77,7 @@ available
 avoid
 azimuth
 azure
+back
 backdrop
 backface
 background
@@ -97,6 +86,7 @@ balance
 bar
 base
 baseline
+basic
 basis
 bdi
 bdo
@@ -127,6 +117,7 @@ bold
 bolder
 bookmark
 border
+borderless
 both
 bottom
 bottomleft
@@ -139,6 +130,7 @@ break
 breaks
 brightness
 brown
+browsertabbar
 buffered
 bullets
 burlywood
@@ -300,10 +292,12 @@ dotted
 double
 doubleposition
 down
+downbutton
 dpcm
 dpi
 dppx
 drop
+dropdown
 dt
 duration
 during
@@ -343,6 +337,7 @@ ex
 exact
 exclude
 exclusion
+extended
 extends
 face
 fade
@@ -353,6 +348,7 @@ fieldset
 figcaption
 figure
 fileTypes
+filetypes
 fill
 filled
 filter
@@ -377,6 +373,7 @@ forestgreen
 form
 formal
 format
+forward
 forwards
 fr
 fragment
@@ -389,10 +386,12 @@ function
 gainsboro
 gap
 garamond
+geometric
 geometricPrecision
 georgia
 georgian
 ghostwhite
+glass
 glyph
 gold
 goldenrod
@@ -440,6 +439,7 @@ http
 hue
 hyphenate
 hyphens
+hz
 i
 icon
 id
@@ -520,6 +520,7 @@ leading
 left
 legacy
 legend
+legibility
 lemonchiffon
 length
 letter
@@ -570,6 +571,7 @@ luminance
 luminosity
 lvmax
 lvmin
+mac
 magenta
 main
 malayalam
@@ -588,6 +590,8 @@ match
 mathematical
 matrix
 max
+maximize
+maximized
 maximum
 media
 medium
@@ -620,6 +624,7 @@ mid
 middle
 midnightblue
 min
+minimize
 minimum
 minmax
 mintcream
@@ -641,6 +646,7 @@ moz
 mozmm
 ms
 multicol
+multiline
 multiply
 myanmar
 n
@@ -653,6 +659,7 @@ negative
 nesw
 new
 newspaper
+next
 no
 non
 none
@@ -719,6 +726,7 @@ padding
 page
 paginate
 paint
+painted
 palegoldenrod
 palegreen
 paleturquoise
@@ -758,9 +766,11 @@ portrait
 position
 powderblue
 pre
+precision
 prefix
 presentation
 preserve
+previous
 print
 profile
 progid
@@ -770,13 +780,16 @@ progresschunk
 progressive
 projection
 property
+propertylist
 proximity
 pseudo
 pt
+public
 punctuation
 purple
 px
 q
+quality
 query
 quote
 quoted
@@ -830,6 +843,8 @@ row
 rows
 royalblue
 rp
+rrggbb
+rrggbbaa
 rt
 rtc
 rtl
@@ -850,6 +865,7 @@ saturation
 scale
 scale-horizontal
 scale-vertical
+scalethumb
 scalethumb-horizontal
 scalethumb-vertical
 scan
@@ -859,12 +875,15 @@ screen
 script
 scroll
 scrollbar-small
+scrollbarbutton
 scrollbarbutton-down
 scrollbarbutton-left
 scrollbarbutton-right
 scrollbarbutton-up
+scrollbarthumb
 scrollbarthumb-horizontal
 scrollbarthumb-vertical
+scrollbartrack
 scrollbartrack-horizontal
 scrollbartrack-vertical
 se
@@ -918,6 +937,7 @@ spacing
 span
 speak
 speech
+speed
 spell
 spinner
 spinner-downbutton
@@ -1004,9 +1024,11 @@ time
 times
 timing
 title
+titlebar
 to
 tomato
 toolbar
+toolbarbutton
 toolbarbutton-dropdown
 toolbox
 tooltip
@@ -1014,6 +1036,7 @@ top
 topleft
 topright
 touch
+tr
 track
 transform
 transition
@@ -1048,12 +1071,14 @@ unsafe
 unscrollable
 unset
 up
+upbutton
 upper
 uppercase
 upright
 url
 use
 user
+utf
 utopia
 uuid
 valid
@@ -1108,7 +1133,9 @@ xx
 y
 yellow
 yellowgreen
+z
 zA
+za
 zero
 zone
 zoom

--- a/dictionaries/css/src/css.txt
+++ b/dictionaries/css/src/css.txt
@@ -54,6 +54,7 @@ arithmetic
 armenian
 around
 array
+arrow
 article
 as
 ascii
@@ -71,6 +72,7 @@ available
 avoid
 azimuth
 azure
+back
 backdrop
 backface
 background
@@ -79,7 +81,7 @@ balance
 bar
 base
 baseline
-Basic
+basic
 basis
 bdi
 bdo
@@ -110,6 +112,7 @@ bold
 bolder
 bookmark
 border
+borderless
 both
 bottom
 bottomleft
@@ -122,6 +125,7 @@ break
 breaks
 brightness
 brown
+browsertabbar
 buffered
 bullets
 burlywood
@@ -283,10 +287,12 @@ dotted
 double
 doubleposition
 down
+downbutton
 dpcm
 dpi
 dppx
 drop
+dropdown
 dt
 duration
 during
@@ -327,7 +333,7 @@ ex
 exact
 exclude
 exclusion
-Extended
+extended
 extends
 face
 fade
@@ -337,6 +343,7 @@ feature
 fieldset
 figcaption
 figure
+filetypes
 fileTypes
 fill
 filled
@@ -362,6 +369,7 @@ forestgreen
 form
 formal
 format
+forward
 forwards
 fr
 fragment
@@ -374,10 +382,12 @@ function
 gainsboro
 gap
 garamond
+geometric
 geometricPrecision
 georgia
 georgian
 ghostwhite
+glass
 glyph
 gold
 goldenrod
@@ -425,6 +435,7 @@ http
 hue
 hyphenate
 hyphens
+hz
 Hz
 i
 icon
@@ -506,7 +517,7 @@ leading
 left
 legacy
 legend
-Legibility
+legibility
 lemonchiffon
 length
 letter
@@ -557,6 +568,7 @@ luminance
 luminosity
 lvmax
 lvmin
+mac
 magenta
 main
 malayalam
@@ -575,6 +587,8 @@ match
 mathematical
 matrix
 max
+maximize
+maximized
 maximum
 media
 medium
@@ -607,6 +621,7 @@ mid
 middle
 midnightblue
 min
+minimize
 minimum
 minmax
 mintcream
@@ -628,6 +643,7 @@ moz
 mozmm
 ms
 multicol
+multiline
 multiply
 myanmar
 n
@@ -640,6 +656,7 @@ negative
 nesw
 new
 newspaper
+next
 no
 non
 none
@@ -706,7 +723,7 @@ padding
 page
 paginate
 paint
-Painted
+painted
 palegoldenrod
 palegreen
 paleturquoise
@@ -746,9 +763,11 @@ portrait
 position
 powderblue
 pre
+precision
 prefix
 presentation
 preserve
+previous
 print
 profile
 progid
@@ -758,16 +777,16 @@ progresschunk
 progressive
 projection
 property
-PropertyList
+propertylist
 proximity
 pseudo
 pt
-PUBLIC
+public
 punctuation
 purple
 px
 q
-Quality
+quality
 query
 quote
 quoted
@@ -821,8 +840,8 @@ row
 rows
 royalblue
 rp
-RRGGBB
-RRGGBBAA
+rrggbb
+rrggbbaa
 rt
 rtc
 rtl
@@ -843,6 +862,7 @@ saturation
 scale
 scale-horizontal
 scale-vertical
+scalethumb
 scalethumb-horizontal
 scalethumb-vertical
 scan
@@ -852,12 +872,15 @@ screen
 script
 scroll
 scrollbar-small
+scrollbarbutton
 scrollbarbutton-down
 scrollbarbutton-left
 scrollbarbutton-right
 scrollbarbutton-up
+scrollbarthumb
 scrollbarthumb-horizontal
 scrollbarthumb-vertical
+scrollbartrack
 scrollbartrack-horizontal
 scrollbartrack-vertical
 se
@@ -911,7 +934,7 @@ spacing
 span
 speak
 speech
-Speed
+speed
 spell
 spinner
 spinner-downbutton
@@ -998,9 +1021,11 @@ time
 times
 timing
 title
+titlebar
 to
 tomato
 toolbar
+toolbarbutton
 toolbarbutton-dropdown
 toolbox
 tooltip
@@ -1008,7 +1033,7 @@ top
 topleft
 topright
 touch
-TR
+tr
 track
 transform
 transition
@@ -1043,13 +1068,14 @@ unsafe
 unscrollable
 unset
 up
+upbutton
 upper
 uppercase
 upright
 url
 use
 user
-UTF
+utf
 utopia
 uuid
 valid
@@ -1104,7 +1130,8 @@ xx
 y
 yellow
 yellowgreen
-Z
+z
+za
 zA
 zero
 zone


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->


## Description

Ensure the new version is compatible with the old one.

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
