### PR TITLE
fix: Make sure Svelte dictionary is loaded for JS and TS

### DIFF
--- a/dictionaries/svelte/cspell-ext.json
+++ b/dictionaries/svelte/cspell-ext.json
@@ -18,7 +18,11 @@
             "languageId": "svelte",
             "locale": "*",
             "dictionaries": ["svelte", "typescript", "npm", "html", "html-symbol-entities", "css", "fonts"]
+        },
+        {
+            "languageId": ["typescript", "javascript"],
+            "dictionaries": ["svelte"]
         }
     ],
-    "overrides": [{ "filename": "**/*.svelte", "languageId": ["svelte", "html"] }]
+    "overrides": [{ "filename": "**/*.svelte", "languageId": ["svelte", "css", "html", "typescript"] }]
 }

--- a/dictionaries/svelte/src/svelte.txt
+++ b/dictionaries/svelte/src/svelte.txt
@@ -143,6 +143,7 @@ subscribe
 subscription
 subsection
 svelte
+sveltejs
 sveltekit
 syntax
 tabindex


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _Svelte_

## Description

- Treat `.svelte` files as `TypeScript`/`CSS`/`HTML` files.

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
