### PR TITLE
fix: Publish Gaming Terms

### DIFF
--- a/dictionaries/gaming-terms/package.json
+++ b/dictionaries/gaming-terms/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@cspell/dict-gaming-terms",
   "version": "1.0.1",
-  "description": "Gaming dictionary for cspell. -- Private until verified",
-  "private": true,
+  "description": "Gaming dictionary for cspell.",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

Make Gaming Terms public so it can be published.

Fix: #1695 