### PR TITLE
add infographic to list of english words

### DIFF
--- a/dictionaries/en_US/src/additional_words.txt
+++ b/dictionaries/en_US/src/additional_words.txt
@@ -35,6 +35,7 @@ flyout
 guillemet
 heatmap
 hmmm
+infographic
 iPads
 Kyiv
 multiline


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: en-US

## Description

Adds the word `infographic` to the list of additional words in the en-US dict

## References

[Merriam-Webster](https://www.merriam-webster.com/dictionary/infographic)

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
