### PR TITLE
fix: Add facebook and instagram to fullstack.txt

### DIFF
--- a/dictionaries/fullstack/fullstack.txt
+++ b/dictionaries/fullstack/fullstack.txt
@@ -107,6 +107,7 @@ errhandler
 esbenp
 esnext
 eventsource
+facebook
 faceforward
 fbid
 fieldisnull
@@ -161,6 +162,7 @@ infilter
 infobackground
 infotext
 inout
+instagram
 intmax
 intptr
 ints


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: fullstack

## Description
Add `facebook` and `instagram`

## References
From this issue https://github.com/streetsidesoftware/cspell-dicts/issues/1700#issuecomment-1360884498

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
