### PR TITLE
fix: Add British Software Terms

### DIFF
--- a/dictionaries/en_GB/src/additional_words.txt
+++ b/dictionaries/en_GB/src/additional_words.txt
@@ -9,6 +9,7 @@ Aruban
 Arubans
 bicep
 Christoph
+computerised
 conformant
 COVID
 dropshipper
@@ -19,8 +20,12 @@ guillemet
 heatmap
 hmmm
 iPads
+parameterise
 prepend
 reauthenticate
+serialisation
+synchronise
+synchronisation
 tricep
 unintuitive
 unmanoeuvrable


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: en_GB

## Description

Closes #193

Added British Software Terms

## References

Used https://www.fda.gov/inspections-compliance-enforcement-and-criminal-investigations/inspection-guides/glossary-computer-system-software-development-terminology-895 as a base for American terms then Cross referenced them with a dictionary to see if a British counterpart existed.

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
