### PR TITLE
fix: Add "mongod" to software terms dictionary.

### DIFF
--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -126,6 +126,7 @@ MegaLinter
 Microsoft
 minikube
 mkdir
+mongod
 MongoDB
 monit
 MySQL


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: software terms

## Description

"mongod" was originally added to the software terms dictionary in #761 but then removed in #1419.

## References

- "mongod is the primary daemon process for the MongoDB system." ~ https://docs.mongodb.com/manual/reference/program/mongod/

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
