### PR TITLE
Update fullstack.txt

### DIFF
--- a/dictionaries/fullstack/fullstack.txt
+++ b/dictionaries/fullstack/fullstack.txt
@@ -64,6 +64,8 @@ createfolder
 cstr
 datagrid
 datagrids
+data-ogsb
+data-ogsc
 datefmt
 datepicker
 datepickers
@@ -266,8 +268,6 @@ NWSE
 obj
 objs
 offcanvas
-ogsb
-ogsc
 oldname
 onconfirm
 onesignal

--- a/dictionaries/fullstack/fullstack.txt
+++ b/dictionaries/fullstack/fullstack.txt
@@ -266,6 +266,8 @@ NWSE
 obj
 objs
 offcanvas
+ogsb
+ogsc
 oldname
 onconfirm
 onesignal


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add Dictionary

Dictionary: Fullstack

## Description

Add `ogsc` & `ogsb` from the outlook e-mail color theme specificities

## References
_Quite a hard time finding an official reference but here is stackoverflow Q&A explaining the feature_
- https://stackoverflow.com/a/62740114/11135174

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
