### PR TITLE
Add `overscroll` to the CSS dictionary

### DIFF
--- a/dictionaries/css/src/css.txt
+++ b/dictionaries/css/src/css.txt
@@ -716,6 +716,7 @@ overhang
 overlay
 overline
 override
+overscroll
 p
 pack
 pad


### PR DESCRIPTION
Currently the [`overscroll-behavior`](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior) property isn't recognized and the `overscroll` part is reported as a misspelling.