### PR TITLE
fix: Add idempotence and toolchains to softwareTerms

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -602,6 +602,7 @@ icmp
 iconv
 id
 idempotent
+idempotence
 ident
 identicon
 ideographic
@@ -1400,6 +1401,7 @@ tokenizer
 tokenizers
 tokenizing
 toolchain
+toolchains
 tooltip
 tooltips
 transact


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: softwareTerms

## Description

Adds 'idempotence' and 'toolchains' to match existing terms 'idempotent' and 'toolchain'

## References

none

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)

fixes: #1824 