### PR TITLE
chore: use `shx` instead of `rimraf` to delete files.

### DIFF
--- a/dictionaries/en_GB/package.json
+++ b/dictionaries/en_GB/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "yarn run compile",
     "sync": "yarn cpy \"../../node_modules/aoo-mozilla-en-dict/en_GB*/**\" \"src/aoo-mozilla-en-dict\" --flat && yarn sync-clean",
-    "sync-clean": "rimraf \"src/*/wordlist*.txt\" \"src/*/*speller*.txt\"",
+    "sync-clean": "shx rm -rf \"src/*/wordlist*.txt\" \"src/*/*speller*.txt\"",
     "checksum": "shasum -c checksum.txt",
     "compile": "cat source-files.txt | xargs cspell-tools-cli compile --trie3 -x compound --merge en_GB -o . --no-compress && yarn run gen-checksum",
     "conditional-build": "yarn run sync && yarn run --silent checksum || yarn run build",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "check-spelling": "cspell",
     "checksum": "lerna run checksum",
     "create-dictionary": "node ./generator-cspell-dicts/node_modules/yo/lib/cli.js cspell-dicts",
-    "clean": "rimraf \"packages/*/*.txt.gz\" \"dictionaries/*/*.txt.gz\"",
+    "clean": "shx rm -rf \"packages/*/*.txt.gz\" \"dictionaries/*/*.txt.gz\"",
     "readme:generate-doc-dictionaries": "./scripts/dictionaries.sh > dictionaries.md && inject-markdown README.md && yarn prettier -w \"*.md\"",
     "readme:update-dictionaries": "inject-markdown \"dictionaries/*/README.md\" && prettier -w \"dictionaries/*/README.md\"",
     "prepare": "lerna run prepare",
@@ -54,7 +54,7 @@
     "inject-markdown": "^1.3.0",
     "json5": "2.2.3",
     "prettier": "^2.8.3",
-    "rimraf": "^3.0.2",
+    "shx": "^0.3.4",
     "yamljs": "^0.3.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5199,7 +5199,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.1.0, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.1.0, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.7"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
   integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
@@ -6910,6 +6910,14 @@ shelljs@^0.8.5:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+shx@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz#74289230b4b663979167f94e1935901406e40f02"
+  integrity sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==
+  dependencies:
+    minimist "^1.2.3"
+    shelljs "^0.8.5"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"


### PR DESCRIPTION
## Description

We used `rimraf` to delete files using glob patterns, this is no longer supported.

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
