### PR TITLE
fix: Add footer to dictionary README.md

### DIFF
--- a/dictionaries/en_GB-MIT/README.md
+++ b/dictionaries/en_GB-MIT/README.md
@@ -48,3 +48,17 @@ Please add any words to [src/additional_words.txt](./src/additional_words.txt) b
 ## License
 
 MIT
+
+<!--- @@inject: ../../static/footer.md --->
+
+<br/>
+
+---
+
+<p align="center">
+Brought to you by <a href="https://streetsidesoftware.com" title="Street Side Software">
+<img width="16" alt="Street Side Software Logo" src="https://i.imgur.com/CyduuVY.png" /> Street Side Software
+</a>
+</p>
+
+<!--- @@inject-end: ../../static/footer.md --->

--- a/dictionaries/en_GB/README.md
+++ b/dictionaries/en_GB/README.md
@@ -55,3 +55,17 @@ Please add any words to [src/additional_words.txt](./src/additional_words.txt) b
 GPL-3.0-or-later
 
 > Some packages may have other licenses included.
+
+<!--- @@inject: ../../static/footer.md --->
+
+<br/>
+
+---
+
+<p align="center">
+Brought to you by <a href="https://streetsidesoftware.com" title="Street Side Software">
+<img width="16" alt="Street Side Software Logo" src="https://i.imgur.com/CyduuVY.png" /> Street Side Software
+</a>
+</p>
+
+<!--- @@inject-end: ../../static/footer.md --->

--- a/dictionaries/en_US/README.md
+++ b/dictionaries/en_US/README.md
@@ -65,3 +65,17 @@ http://wordlist.aspell.net/hunspell-readme/
 MIT
 
 > Some packages may have other licenses included.
+
+<!--- @@inject: ../../static/footer.md --->
+
+<br/>
+
+---
+
+<p align="center">
+Brought to you by <a href="https://streetsidesoftware.com" title="Street Side Software">
+<img width="16" alt="Street Side Software Logo" src="https://i.imgur.com/CyduuVY.png" /> Street Side Software
+</a>
+</p>
+
+<!--- @@inject-end: ../../static/footer.md --->

--- a/dictionaries/fr_FR/README.md
+++ b/dictionaries/fr_FR/README.md
@@ -49,4 +49,18 @@ The Hunspell source for this dictionary can be found:
 
 MIT
 
-See also: [French.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/fr_FR/French.txt)
+See also: [French.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/fr_FR/src/hunspell-french-dictionaries-v7.0/README_dict_fr.txt)
+
+<!--- @@inject: ../../static/footer.md --->
+
+<br/>
+
+---
+
+<p align="center">
+Brought to you by <a href="https://streetsidesoftware.com" title="Street Side Software">
+<img width="16" alt="Street Side Software Logo" src="https://i.imgur.com/CyduuVY.png" /> Street Side Software
+</a>
+</p>
+
+<!--- @@inject-end: ../../static/footer.md --->

--- a/dictionaries/fr_FR_90/README.md
+++ b/dictionaries/fr_FR_90/README.md
@@ -44,3 +44,17 @@ npm run build
 MIT
 
 > Some packages may have other licenses included.
+
+<!--- @@inject: ../../static/footer.md --->
+
+<br/>
+
+---
+
+<p align="center">
+Brought to you by <a href="https://streetsidesoftware.com" title="Street Side Software">
+<img width="16" alt="Street Side Software Logo" src="https://i.imgur.com/CyduuVY.png" /> Street Side Software
+</a>
+</p>
+
+<!--- @@inject-end: ../../static/footer.md --->

--- a/generator-cspell-dicts/generators/app/templates/README.md
+++ b/generator-cspell-dicts/generators/app/templates/README.md
@@ -46,3 +46,5 @@ See: [How to Create a New Dictionary](https://github.com/streetsidesoftware/cspe
 MIT
 
 > Some packages may have other licenses included.
+
+<!--- @@inject: ../../static/footer.md --->


### PR DESCRIPTION
This PR starts the process of adding footers to all the dictionaries:

```markdown
<!--- @@inject: ../../static/footer.md --->

<br/>

---

<p align="center">
Brought to you by <a href="https://streetsidesoftware.com" title="Street Side Software">
<img width="16" alt="Street Side Software Logo" src="https://i.imgur.com/CyduuVY.png" /> Street Side Software
</a>
</p>

<!--- @@inject-end: ../../static/footer.md --->
```

<br/>

---

<p align="center">
Brought to you by <a href="https://streetsidesoftware.com" title="Street Side Software">
<img width="16" alt="Street Side Software Logo" src="https://i.imgur.com/CyduuVY.png" /> Street Side Software
</a>
</p>
