### PR TITLE
Add "OXSecurity" to software tools dictionary

### DIFF
--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -155,6 +155,7 @@ openSUSE
 OpenVPN
 OpenVZ
 Ouroboros
+OXSecurity
 perl
 php
 Pidora


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: software tools

## Description

OXSecurity is the organization that MegaLinter's Docker images are hosted under.

## References

- https://github.com/oxsecurity/megalinter
- https://hub.docker.com/r/oxsecurity/megalinter

## Checklist

- [x] By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)