### PR TITLE
fix: Encourage the correct spelling of `programming`.

### DIFF
--- a/dictionaries/cpp/src/cpp.txt
+++ b/dictionaries/cpp/src/cpp.txt
@@ -60995,7 +60995,6 @@ progname
 progp
 program
 ProgramArguments
-programing
 programmable
 programmatically
 programmer

--- a/dictionaries/en-common-misspellings/dict-en.yaml
+++ b/dictionaries/en-common-misspellings/dict-en.yaml
@@ -6,6 +6,8 @@
 # The words below apply to both US English and British English
 dictionaryDefinitions:
   - name: en-common-misspellings
+    flagWords:
+      - programing->programming
     suggestWords:
       - abandonned->abandoned
       - abbout->about

--- a/generator-cspell-dicts/generators/app/index.js
+++ b/generator-cspell-dicts/generators/app/index.js
@@ -75,7 +75,7 @@ module.exports = class extends Generator {
             {
                 type: 'input',
                 name: 'languageId',
-                message: 'Programing languageID/filetype, i.e. "typescript", "php", "go", or "*" for any.',
+                message: 'Programming languageID/filetype, i.e. "typescript", "php", "go", or "*" for any.',
                 default: '*',
             },
             {


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: `en-common-misspellings`

## Description

Even though `programing` is a word, it is no longer considered correct.

See: [Ngram: programing vs programming](https://books.google.com/ngrams/graph?content=programming%2Cprograming%2Ccoding&year_start=1900&year_end=2019&corpus=en-2019&smoothing=3)

<a href="https://books.google.com/ngrams/graph?content=programming%2Cprograming%2Ccoding&year_start=1900&year_end=2019&corpus=en-2019&smoothing=3"><img width="1554" alt="Image, programing vs programming" src="https://user-images.githubusercontent.com/3740137/219025193-ed3008ce-92f1-4fb7-bfca-98770ec04279.png"></a>


## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
