### PR TITLE
fix: Add `noindex` to fullstack.txt

### DIFF
--- a/dictionaries/fullstack/src/fullstack.txt
+++ b/dictionaries/fullstack/src/fullstack.txt
@@ -246,6 +246,7 @@ nocache
 nocursor
 noexcept
 nohost
+noindex
 nolink
 nomatch
 nomodule


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: fullstack

## Description

Add the `noindex` since it may be used in `js` and `ts` files

## References

[- _Any source references._](https://developers.google.com/search/docs/advanced/crawling/block-indexing?hl=fr)

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
