### PR TITLE
fix: Adds missing words to Fonts and fixes oreder

### DIFF
--- a/dictionaries/fonts/fonts.txt
+++ b/dictionaries/fonts/fonts.txt
@@ -181,6 +181,7 @@ BungeeHairline
 BungeeInline
 BungeeOutline
 BungeeShade
+Busorama
 Butcherman
 ButterflyKids
 Cabin
@@ -770,9 +771,9 @@ Milonga
 Miltonian
 MiltonianTattoo
 MingLiU
+MingLiU-ExtB
 MingLiU_HKSCS
 MingLiU_HKSCS-ExtB
-MingLiU-ExtB
 Minion Web
 Miniver
 Miriam
@@ -1281,6 +1282,7 @@ Yellowtail
 YesevaOne
 Yesteryear
 Yrsa
+Ysabeau
 Yu Gothic Bold
 Yu Gothic Light
 Yu Gothic Medium


### PR DESCRIPTION
# Fix Dictionary

Dictionary: ```fonts```

## Description

Adds Missing Words
* Ysabeau
*  Busorama

## References

https://github.com/streetsidesoftware/cspell-dicts/issues/1897

## Checklist

- [X] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
