### PR TITLE
fix: Adds Missing words to `CSS` and fixes order

### DIFF
--- a/dictionaries/css/src/css.txt
+++ b/dictionaries/css/src/css.txt
@@ -137,6 +137,7 @@ button-arrow-previous
 button-arrow-up
 button-bevel
 cadetblue
+calt
 cambodian
 canvas
 capitalize
@@ -169,6 +170,7 @@ cjk
 class
 clear
 clearfix
+clig
 clip
 clone
 close
@@ -553,6 +555,7 @@ lines
 link
 list
 listbox
+lnum
 local
 logic
 logical
@@ -930,8 +933,8 @@ soft
 solid
 source
 space
-spacegrey
 spacegray
+spacegrey
 spaces
 spacing
 span
@@ -1025,6 +1028,7 @@ times
 timing
 title
 titlebar
+tnum
 to
 tomato
 toolbar
@@ -1134,8 +1138,9 @@ y
 yellow
 yellowgreen
 z
-za
 zA
+za
 zero
+zindex
 zone
 zoom

--- a/dictionaries/css/src/css.txt
+++ b/dictionaries/css/src/css.txt
@@ -1141,6 +1141,5 @@ z
 zA
 za
 zero
-zindex
 zone
 zoom


### PR DESCRIPTION

# Fix Dictionary

Dictionary: ```css```

## Description

Adds Missing words to CSS 
* clig
* calt
* lnum
* tnum
* zindex

Fixes order

## References

https://github.com/streetsidesoftware/cspell-dicts/issues/1897

## Checklist

- [X] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
