### PR TITLE
fix: Adds some missing Words to NPM

### DIFF
--- a/dictionaries/npm/src/npm.txt
+++ b/dictionaries/npm/src/npm.txt
@@ -133,6 +133,7 @@ emmet
 enumtype
 errorhandler
 es6-promise
+esbuild
 eslint
 eslint-config-airbnb
 eslintcache
@@ -159,6 +160,7 @@ fibers
 figlet
 firebase
 flatpak-bundler
+flatpickr
 flightplan
 fluent-ffmpeg
 flux
@@ -355,6 +357,7 @@ isomorphic-fetch
 istanbul
 istanbuljs
 jade
+jarallax
 jasmine
 jekyllrb
 jimp
@@ -364,6 +367,7 @@ jotai
 jquery
 js-beautify
 js-yaml
+jsbundling
 jscpd
 jscs
 jsdoc
@@ -407,6 +411,7 @@ lowdb
 lru-cache
 lwip
 main-bower-files
+mapboxgl
 markdown
 markdown-it
 markdown-pdf
@@ -427,6 +432,7 @@ mime
 mime-types
 minimatch
 minimist
+mkcert
 mkdirp
 mobx
 mobx
@@ -446,6 +452,7 @@ mssql
 multer
 multiparty
 mustache
+muuri
 mysql
 n
 nan
@@ -510,6 +517,7 @@ ora
 orchestrator
 orm
 pageres
+pagy
 parallelshell
 passport
 passport-facebook


### PR DESCRIPTION
# Fix Dictionary

Dictionary: ```npm```

## Description

Adds words to NPM
* flatpickr
* jarallax
* mapboxgl
* jsbundling
* muuri
* pagy
* esbuild
* mkcert

## References

https://github.com/streetsidesoftware/cspell-dicts/issues/1897

## Checklist

- [X] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
