### PR TITLE
fix: Adds missing words to `companies`

### DIFF
--- a/dictionaries/companies/src/companies.txt
+++ b/dictionaries/companies/src/companies.txt
@@ -22,8 +22,8 @@ Adobe Inc.
 ADSK
 Advance Auto Parts
 Advance Auto Parts, Inc.
-Advanced Micro Devices, Inc.
 Advanced Micro Devices Inc
+Advanced Micro Devices, Inc.
 AECOM Technology Corporation
 Aegon
 AEON
@@ -35,20 +35,20 @@ AFLAC Inc
 Aflac Incorporated
 Agari Data, Inc.
 AGCO Corporation
-Agilent Technologies, Inc.
 Agilent Technologies Inc
+Agilent Technologies, Inc.
 Agricultural Bank of China
-Airbnb, Inc.
 Air France-KLM Group
-Airgas, Inc.
-Air Products & Chemicals, Inc.
 Air Products & Chemicals Inc
+Air Products & Chemicals, Inc.
+Airbnb, Inc.
+Airgas, Inc.
 Aisin Seiki
+AK Steel Holding Corporation
 AKAM
 Akamai Technologies Inc
-AK Steel Holding Corporation
-Alaska Air Group, Inc.
 Alaska Air Group Inc
+Alaska Air Group, Inc.
 Albemarle Corp
 Alcoa
 Alcoa Inc.
@@ -68,8 +68,8 @@ Allstate Corp
 Ally Financial Inc.
 Alphabet Inc.
 Alstom
-Altria Group, Inc.
 Altria Group Inc
+Altria Group, Inc.
 Aluminum Corp. of China
 AMAT
 Amazon.com
@@ -121,15 +121,15 @@ Apartment Investment & Management
 Appetize
 Apple
 Apple Inc.
-Applied Materials, Inc.
 Applied Materials Inc.
+Applied Materials, Inc.
 Appointedd
 Aptiv PLC
 APTV
 Aramark Holdings Corporation
 ArcelorMittal
-Archer-Daniels-Midland Co
 Archer Daniels Midland
+Archer-Daniels-Midland Co
 Arista Networks
 Arrow Electronics, Inc
 Arthur J. Gallagher & Co.
@@ -152,8 +152,8 @@ Automatic Data Processing
 Automatic Data Processing, Inc.
 Automattic Inc.
 AutoNation, Inc.
-AutoZone, Inc.
 AutoZone Inc
+AutoZone, Inc.
 AvalonBay Communities
 Avery Dennison Corp
 Avery Dennison Corporation
@@ -192,15 +192,15 @@ Baxter International Inc.
 Bayer
 Bazaarvoice
 BB&T Corporation
-Becton, Dickinson and Company
 Becton Dickinson
+Becton, Dickinson and Company
 Bed Bath & Beyond Inc.
 Bemis Company, Inc.
 Berkshire Hathaway
 Bertelsmann
 Best Buy
-Best Buy Co., Inc.
 Best Buy Co. Inc.
+Best Buy Co., Inc.
 BF.B
 Bharat Petroleum
 BHP Billiton
@@ -264,8 +264,8 @@ Capital One Financial
 Capital One Financial Corporation
 Cardinal Health
 Cardinal Health Inc.
-CarMax, Inc.
 Carmax Inc
+CarMax, Inc.
 Carnival Corp.
 CARR
 Carrefour
@@ -281,7 +281,7 @@ CBRE Group
 CBRE Group, Inc.
 CBS Corporation
 CC Media Holdings, Inc.
-Cdnjs
+cdnjs
 CDNS
 CDW Corporation
 Celanese
@@ -296,9 +296,9 @@ CenturyLink, Inc.
 CERN
 Cerner
 Certum
-CFE
-CF Industries Holdings, Inc.
 CF Industries Holdings Inc
+CF Industries Holdings, Inc.
+CFE
 CH2M HILL Companies, Ltd.
 Chambersign
 Charles Schwab Corporation
@@ -335,8 +335,8 @@ China Railway Group
 China Railway Materials
 China Resources National
 China Shipbuilding Industry
-China Southern Power Grid
 China South Industries Group
+China Southern Power Grid
 China State Construction Engineering
 China Telecommunications
 China United Network Communications
@@ -439,9 +439,9 @@ D.R. Horton, Inc.
 Dai-ichi Life Insurance
 Daimler
 Daiwa House Industry
+Dana Holding Corporation
 Danaher Corp.
 Danaher Corporation
-Dana Holding Corporation
 Danone
 Darden Restaurants
 Darden Restaurants, Inc.
@@ -458,8 +458,8 @@ Deere & Company
 Delhaize Group
 Dell
 Delta Air Lines
-Delta Air Lines, Inc.
 Delta Air Lines Inc.
+Delta Air Lines, Inc.
 Denso
 Dentsply Sirona
 Deutsche Bahn
@@ -481,8 +481,8 @@ DirecTV
 DISCA
 DISCK
 Discover Financial Services
-Discovery, Inc.
 Discovery Communications, Inc.
+Discovery, Inc.
 DISH
 Dish Network
 DISH Network Corporation
@@ -508,8 +508,8 @@ Duke Energy Corporation
 Duke Realty Corp
 DuPont
 DuPont de Nemours Inc
-DXCM
 DXC Technology
+DXCM
 DZ Bank
 E.I. du Pont de Nemours and Company
 E.ON
@@ -602,9 +602,9 @@ Finmeccanica
 Fireblocks
 First American Financial Corporation
 First Data Corporation
+First Republic Bank
 FirstEnergy Corp
 FirstEnergy Corp.
-First Republic Bank
 Fiserv Inc
 FISV
 FITB
@@ -627,8 +627,8 @@ Formosa Petrochemical
 Fortinet
 Fortive Corp
 Fortune Brands Home & Security
-FOXA
 Fox Corporation
+FOXA
 France Telecom
 Franklin Resources
 Franklin Resources, Inc.
@@ -723,8 +723,8 @@ Heraeus Holding
 Hertz Global Holdings, Inc.
 Hess
 Hess Corporation
-Hewlett-Packard
 Hewlett Packard Enterprise
+Hewlett-Packard
 Hilton Worldwide Holdings Inc.
 Hindustan Petroleum
 Hipercard
@@ -736,11 +736,11 @@ HollyFrontier Corporation
 Hologic
 HOLX
 Home Depot
+Hon Hai Precision Industry
 Honda Motor
 Honeywell Int'l Inc.
 Honeywell International
 Honeywell International Inc.
-Hon Hai Precision Industry
 Hormel Foods Corp.
 Hormel Foods Corporation
 Host Hotels & Resorts
@@ -750,13 +750,13 @@ HP Inc.
 HSBC Holdings
 HSIC
 Huawei Investment & Holding
-Hulu
 Humana
 Humana Inc.
 Huntington Bancshares
 Huntington Ingalls Industries
 Huntington Ingalls Industries, Inc.
 Huntsman Corporation
+Hulu
 Husky Energy
 Hutchison Whampoa
 Hyundai Heavy Industries
@@ -776,7 +776,6 @@ Illinois Tool Works Inc.
 Illumina (company)
 Illumina Inc
 ILMN
-imessage
 Imgix
 Imperial Tobacco Group
 INAP
@@ -789,8 +788,8 @@ INFO
 Infomaniak
 Information Technology
 Infosys
-Ingersoll Rand
 ING Group
+Ingersoll Rand
 Ingram Micro
 Ingram Micro Inc.
 Ingredion Incorporated
@@ -816,9 +815,9 @@ INTU
 Intuit Inc.
 Intuitive Surgical Inc.
 Invesco Ltd.
-IPGP
 IPG Photonics
 IPG Photonics Corp.
+IPGP
 IQVIA
 IQVIA Holdings Inc.
 Iron Mountain Incorporated
@@ -827,10 +826,10 @@ IssueHunt
 Itausa-Investimentos
 Itochu
 J. B. Hunt Transport Services
+J. Sainsbury
 J.B. Hunt Transport Services, Inc.
 J.C. Penney Company, Inc.
 J.P. Morgan Chase & Co.
-J. Sainsbury
 Jabil Circuit, Inc.
 Jack Henry & Associates
 Jacobs Engineering Group
@@ -851,10 +850,10 @@ JM Smucker
 JNPR
 Johnson & Johnson
 Johnson Controls
-Johnson Controls, Inc.
 Johnson Controls International
-Joyent
+Johnson Controls, Inc.
 Joy Global Inc.
+Joyent
 JPMorgan Chase & Co.
 Juniper Networks
 JX Holdings
@@ -880,8 +879,8 @@ Kinder Morgan
 Kinder Morgan, Inc.
 Kindred Healthcare, Inc.
 KKR & Co. L.P.
-KLAC
 KLA Corporation
+KLAC
 Ko-fi
 Kobe Steel
 Kohl's Corporation
@@ -897,25 +896,25 @@ Kroger
 Kroger Co.
 KUKA
 KupiVIP Group
-L'Oreal
+L Brands Inc.
+L Brands, Inc.
 L-3 Communications Holdings, Inc.
 L.M. Ericsson
+L'Oreal
 L3Harris Technologies
+La Poste
 Laboratory Corp. of America Holding
 Laboratory Corporation of America Holdings
 Lafarge
+Lam Research
 Lamb Weston Holdings Inc
 Lamoda
-Lam Research
-Landesbank Baden-Wurttemberg
 Land O'Lakes, Inc.
-La Poste
-Last.fm
-Lastfm
+Landesbank Baden-Wurttemberg
 Las Vegas Sands
 Las Vegas Sands Corp.
-L Brands, Inc.
-L Brands Inc.
+Lastfm
+Last.fm
 LDOS
 Lear Corporation
 Leaseweb
@@ -1008,8 +1007,8 @@ MDLZ
 MeadWestvaco Corporation
 Medco Health Solutions
 Medipal Holdings
-Medtronic, Inc.
 Medtronic plc
+Medtronic, Inc.
 Meiji Yasuda Life Insurance
 Merck
 Merck & Co.
@@ -1054,8 +1053,8 @@ Monster Beverage
 Moody's Corp
 Moovit
 Morgan Stanley
-Motorola Solutions, Inc.
 Motorola Solutions Inc.
+Motorola Solutions, Inc.
 Mouseflow
 Mozilla
 Mozilla Corporation
@@ -1077,8 +1076,8 @@ Nasdaq
 Nasdaq, Inc.
 National Australia Bank
 National Grid
-National Oilwell Varco, Inc.
 National Oilwell Varco Inc.
+National Oilwell Varco, Inc.
 Nationwide
 Nationwide Mutual Insurance Co.
 Navistar International Corporation
@@ -1091,6 +1090,8 @@ NetApp
 NetApp, Inc.
 Netflix Inc.
 Netlify
+New York Life Insurance
+New York Life Insurance Company
 Newell Brands
 Newell Rubbermaid Inc.
 Newmont Corporation
@@ -1098,8 +1099,6 @@ Newmont Mining Corporation
 News Corp.
 News Corp. Class A
 News Corp. Class B
-New York Life Insurance
-New York Life Insurance Company
 NextEra Energy
 NextEra Energy, Inc.
 NFLX
@@ -1180,8 +1179,8 @@ Otechie
 OTIS
 Otis Worldwide
 Owens & Minor, Inc.
-Owens-Illinois, Inc.
 Owens Corning
+Owens-Illinois, Inc.
 Ozon Group
 PACCAR Inc
 PACCAR Inc.
@@ -1281,8 +1280,8 @@ QRVO
 QUALCOMM Inc.
 Qualcomm Incorporated
 Quanta Computer
-Quanta Services, Inc.
 Quanta Services Inc.
+Quanta Services, Inc.
 Quest Diagnostics
 Quest Diagnostics Incorporated
 Quintiles Transnational Holdings Inc.
@@ -1300,8 +1299,8 @@ RBS
 Reaktor
 Realogy Holdings Corp.
 Realty Income Corporation
-Reddit, Inc.
 Red Hat, Inc.
+Reddit, Inc.
 Regency Centers Corporation
 Regeneron Pharmaceuticals
 Regions Financial Corp.
@@ -1312,8 +1311,8 @@ Reliance Industries
 Reliance Steel & Aluminum Co.
 Renault
 Repsol YPF
-Republic Services, Inc.
 Republic Services Inc
+Republic Services, Inc.
 ResMed
 Responsys
 Reynolds American Inc.
@@ -1325,8 +1324,8 @@ Robert Bosch
 Robert Half International
 Roche Group
 Rock-Tenn Company
-Rockwell Automation, Inc.
 Rockwell Automation Inc.
+Rockwell Automation, Inc.
 Rollins Inc.
 Roper Technologies
 Rosneft Oil
@@ -1342,8 +1341,8 @@ Royal Philips Electronics
 Ruuvi Innovations Ltd
 RWE
 Ryder System, Inc.
-S&P Global, Inc.
 S-Oil
+S&P Global, Inc.
 Sabic
 Safeway
 Safeway Inc.
@@ -1355,8 +1354,8 @@ Samsung Electronics
 SanDisk Corporation
 Sanmina
 Sanofi
-SBAC
 SBA Communications
+SBAC
 Sberbank
 SBUX
 Schlumberger
@@ -1384,8 +1383,8 @@ Shougang Group
 Showa Shell Sekiyu
 SHV Holdings
 Siemens
-Simon Property Group, Inc.
 Simon Property Group Inc
+Simon Property Group, Inc.
 SinnerSchrader Deutschland GmbH
 Sinochem Group
 Sinomach
@@ -1448,8 +1447,8 @@ Sumitomo Chemical
 Sumitomo Electric Industries
 Sumitomo Life Insurance
 Sumitomo Mitsui Financial Group
-Suncor Energy
 Sun Life Financial
+Suncor Energy
 Sunoco
 SunTrust Banks, Inc.
 Superfeedr
@@ -1461,8 +1460,8 @@ Susser Holdings Corporation
 Suzuken
 Suzuki Motor
 SVB Financial
-Swisscom
 Swiss Re
+Swisscom
 SWKS
 Swyftx
 Symantec Corporation
@@ -1473,10 +1472,10 @@ Synopsys Inc.
 Sysco
 Sysco Corp.
 Sysco Corporation
-T&D Holdings
 T-Mobile
 T-Mobile US
 T. Rowe Price Group
+T&D Holdings
 Take-Two Interactive
 Tapestry, Inc.
 Targa Resources Corp.
@@ -1484,12 +1483,12 @@ Target
 Target Corp.
 Tata Motors
 Tata Steel
-Tech Data
-Tech Data Corporation
-TechnipFMC
-TechRadar
 TE Connectivity
 TE Connectivity Ltd.
+Tech Data
+Tech Data Corporation
+TechRadar
+TechnipFMC
 Telecom Italia
 Teledyne Technologies
 Teleflex
@@ -1532,16 +1531,16 @@ The Pantry, Inc.
 The PNC Financial Services Group, Inc.
 The Priceline Group Inc.
 The Progressive Corporation
-Thermo Fisher Scientific
-Thermo Fisher Scientific Inc.
 The Sherwin-Williams Company
 The Southern Company
 The TJX Companies, Inc.
-The Travelers Companies, Inc.
 The Travelers Companies Inc.
+The Travelers Companies, Inc.
 The Walt Disney Company
 The Western Union Company
 The Williams Companies, Inc.
+Thermo Fisher Scientific
+Thermo Fisher Scientific Inc.
 Thrivent Financial for Lutherans
 ThyssenKrupp
 TIAA-CREF
@@ -1605,8 +1604,6 @@ Union Pacific Corporation
 United Airlines Holdings
 United Continental Holdings
 United Continental Holdings, Inc.
-UnitedHealth Group
-UnitedHealth Group Inc.
 United Natural Foods, Inc.
 United Parcel Service
 United Rentals, Inc.
@@ -1614,6 +1611,8 @@ United Services Automobile Association
 United States Steel Corporation
 United Stationers Inc.
 United Technologies
+UnitedHealth Group
+UnitedHealth Group Inc.
 Universal Health Services
 Universal Health Services, Inc.
 Universiteit Gent
@@ -1633,15 +1632,15 @@ Veikkaus Oy
 Ventas Inc
 Veolia Environnement
 Verdaccio
-Verisign, Inc.
 Verisign Inc.
+Verisign, Inc.
 Verisk Analytics
 Verizon Communications
 Vertex Pharmaceuticals Inc
 VF Corporation
 VIAC
-ViacomCBS
 Viacom Inc.
+ViacomCBS
 Viber
 Vimeo, Inc.
 Vinci
@@ -1668,8 +1667,8 @@ Walgreen Co.
 Walgreens Boots Alliance
 Walmart
 Walt Disney
-Waste Management, Inc.
 Waste Management Inc.
+Waste Management, Inc.
 Waters Corporation
 Waze
 WEC Energy Group
@@ -1680,13 +1679,13 @@ Wells Fargo
 Welltower Inc.
 WESCO International, Inc.
 Wesfarmers
+West Pharmaceutical Services
 Western Digital
 Western Digital Corporation
 Western Refining, Inc.
 Western Union Co
 Westinghouse Air Brake Technologies Corp
 Westpac Banking
-West Pharmaceutical Services
 WestRock
 Weyerhaeuser
 Weyerhaeuser Company
@@ -1709,8 +1708,8 @@ World Fuel Services Corporation
 Wuhan Iron & Steel
 Wyndham Worldwide Corporation
 WYNN
-Wynn Resorts, Limited
 Wynn Resorts Ltd
+Wynn Resorts, Limited
 Xbox
 Xcel Energy Inc.
 Xerox

--- a/dictionaries/companies/src/companies.txt
+++ b/dictionaries/companies/src/companies.txt
@@ -22,8 +22,8 @@ Adobe Inc.
 ADSK
 Advance Auto Parts
 Advance Auto Parts, Inc.
-Advanced Micro Devices Inc
 Advanced Micro Devices, Inc.
+Advanced Micro Devices Inc
 AECOM Technology Corporation
 Aegon
 AEON
@@ -35,20 +35,20 @@ AFLAC Inc
 Aflac Incorporated
 Agari Data, Inc.
 AGCO Corporation
-Agilent Technologies Inc
 Agilent Technologies, Inc.
+Agilent Technologies Inc
 Agricultural Bank of China
-Air France-KLM Group
-Air Products & Chemicals Inc
-Air Products & Chemicals, Inc.
 Airbnb, Inc.
+Air France-KLM Group
 Airgas, Inc.
+Air Products & Chemicals, Inc.
+Air Products & Chemicals Inc
 Aisin Seiki
-AK Steel Holding Corporation
 AKAM
 Akamai Technologies Inc
-Alaska Air Group Inc
+AK Steel Holding Corporation
 Alaska Air Group, Inc.
+Alaska Air Group Inc
 Albemarle Corp
 Alcoa
 Alcoa Inc.
@@ -68,8 +68,8 @@ Allstate Corp
 Ally Financial Inc.
 Alphabet Inc.
 Alstom
-Altria Group Inc
 Altria Group, Inc.
+Altria Group Inc
 Aluminum Corp. of China
 AMAT
 Amazon.com
@@ -121,15 +121,15 @@ Apartment Investment & Management
 Appetize
 Apple
 Apple Inc.
-Applied Materials Inc.
 Applied Materials, Inc.
+Applied Materials Inc.
 Appointedd
 Aptiv PLC
 APTV
 Aramark Holdings Corporation
 ArcelorMittal
-Archer Daniels Midland
 Archer-Daniels-Midland Co
+Archer Daniels Midland
 Arista Networks
 Arrow Electronics, Inc
 Arthur J. Gallagher & Co.
@@ -152,8 +152,8 @@ Automatic Data Processing
 Automatic Data Processing, Inc.
 Automattic Inc.
 AutoNation, Inc.
-AutoZone Inc
 AutoZone, Inc.
+AutoZone Inc
 AvalonBay Communities
 Avery Dennison Corp
 Avery Dennison Corporation
@@ -192,15 +192,15 @@ Baxter International Inc.
 Bayer
 Bazaarvoice
 BB&T Corporation
-Becton Dickinson
 Becton, Dickinson and Company
+Becton Dickinson
 Bed Bath & Beyond Inc.
 Bemis Company, Inc.
 Berkshire Hathaway
 Bertelsmann
 Best Buy
-Best Buy Co. Inc.
 Best Buy Co., Inc.
+Best Buy Co. Inc.
 BF.B
 Bharat Petroleum
 BHP Billiton
@@ -264,8 +264,8 @@ Capital One Financial
 Capital One Financial Corporation
 Cardinal Health
 Cardinal Health Inc.
-Carmax Inc
 CarMax, Inc.
+Carmax Inc
 Carnival Corp.
 CARR
 Carrefour
@@ -281,6 +281,7 @@ CBRE Group
 CBRE Group, Inc.
 CBS Corporation
 CC Media Holdings, Inc.
+Cdnjs
 CDNS
 CDW Corporation
 Celanese
@@ -295,9 +296,9 @@ CenturyLink, Inc.
 CERN
 Cerner
 Certum
-CF Industries Holdings Inc
-CF Industries Holdings, Inc.
 CFE
+CF Industries Holdings, Inc.
+CF Industries Holdings Inc
 CH2M HILL Companies, Ltd.
 Chambersign
 Charles Schwab Corporation
@@ -334,8 +335,8 @@ China Railway Group
 China Railway Materials
 China Resources National
 China Shipbuilding Industry
-China South Industries Group
 China Southern Power Grid
+China South Industries Group
 China State Construction Engineering
 China Telecommunications
 China United Network Communications
@@ -438,9 +439,9 @@ D.R. Horton, Inc.
 Dai-ichi Life Insurance
 Daimler
 Daiwa House Industry
-Dana Holding Corporation
 Danaher Corp.
 Danaher Corporation
+Dana Holding Corporation
 Danone
 Darden Restaurants
 Darden Restaurants, Inc.
@@ -457,8 +458,8 @@ Deere & Company
 Delhaize Group
 Dell
 Delta Air Lines
-Delta Air Lines Inc.
 Delta Air Lines, Inc.
+Delta Air Lines Inc.
 Denso
 Dentsply Sirona
 Deutsche Bahn
@@ -480,8 +481,8 @@ DirecTV
 DISCA
 DISCK
 Discover Financial Services
-Discovery Communications, Inc.
 Discovery, Inc.
+Discovery Communications, Inc.
 DISH
 Dish Network
 DISH Network Corporation
@@ -507,8 +508,8 @@ Duke Energy Corporation
 Duke Realty Corp
 DuPont
 DuPont de Nemours Inc
-DXC Technology
 DXCM
+DXC Technology
 DZ Bank
 E.I. du Pont de Nemours and Company
 E.ON
@@ -601,9 +602,9 @@ Finmeccanica
 Fireblocks
 First American Financial Corporation
 First Data Corporation
-First Republic Bank
 FirstEnergy Corp
 FirstEnergy Corp.
+First Republic Bank
 Fiserv Inc
 FISV
 FITB
@@ -626,8 +627,8 @@ Formosa Petrochemical
 Fortinet
 Fortive Corp
 Fortune Brands Home & Security
-Fox Corporation
 FOXA
+Fox Corporation
 France Telecom
 Franklin Resources
 Franklin Resources, Inc.
@@ -722,8 +723,8 @@ Heraeus Holding
 Hertz Global Holdings, Inc.
 Hess
 Hess Corporation
-Hewlett Packard Enterprise
 Hewlett-Packard
+Hewlett Packard Enterprise
 Hilton Worldwide Holdings Inc.
 Hindustan Petroleum
 Hipercard
@@ -735,11 +736,11 @@ HollyFrontier Corporation
 Hologic
 HOLX
 Home Depot
-Hon Hai Precision Industry
 Honda Motor
 Honeywell Int'l Inc.
 Honeywell International
 Honeywell International Inc.
+Hon Hai Precision Industry
 Hormel Foods Corp.
 Hormel Foods Corporation
 Host Hotels & Resorts
@@ -749,6 +750,7 @@ HP Inc.
 HSBC Holdings
 HSIC
 Huawei Investment & Holding
+Hulu
 Humana
 Humana Inc.
 Huntington Bancshares
@@ -774,6 +776,8 @@ Illinois Tool Works Inc.
 Illumina (company)
 Illumina Inc
 ILMN
+imessage
+Imgix
 Imperial Tobacco Group
 INAP
 INCY
@@ -785,8 +789,8 @@ INFO
 Infomaniak
 Information Technology
 Infosys
-ING Group
 Ingersoll Rand
+ING Group
 Ingram Micro
 Ingram Micro Inc.
 Ingredion Incorporated
@@ -812,9 +816,9 @@ INTU
 Intuit Inc.
 Intuitive Surgical Inc.
 Invesco Ltd.
+IPGP
 IPG Photonics
 IPG Photonics Corp.
-IPGP
 IQVIA
 IQVIA Holdings Inc.
 Iron Mountain Incorporated
@@ -823,10 +827,10 @@ IssueHunt
 Itausa-Investimentos
 Itochu
 J. B. Hunt Transport Services
-J. Sainsbury
 J.B. Hunt Transport Services, Inc.
 J.C. Penney Company, Inc.
 J.P. Morgan Chase & Co.
+J. Sainsbury
 Jabil Circuit, Inc.
 Jack Henry & Associates
 Jacobs Engineering Group
@@ -847,10 +851,10 @@ JM Smucker
 JNPR
 Johnson & Johnson
 Johnson Controls
-Johnson Controls International
 Johnson Controls, Inc.
-Joy Global Inc.
+Johnson Controls International
 Joyent
+Joy Global Inc.
 JPMorgan Chase & Co.
 Juniper Networks
 JX Holdings
@@ -876,8 +880,8 @@ Kinder Morgan
 Kinder Morgan, Inc.
 Kindred Healthcare, Inc.
 KKR & Co. L.P.
-KLA Corporation
 KLAC
+KLA Corporation
 Ko-fi
 Kobe Steel
 Kohl's Corporation
@@ -893,25 +897,25 @@ Kroger
 Kroger Co.
 KUKA
 KupiVIP Group
-L Brands Inc.
-L Brands, Inc.
+L'Oreal
 L-3 Communications Holdings, Inc.
 L.M. Ericsson
-L'Oreal
 L3Harris Technologies
-La Poste
 Laboratory Corp. of America Holding
 Laboratory Corporation of America Holdings
 Lafarge
-Lam Research
 Lamb Weston Holdings Inc
 Lamoda
-Land O'Lakes, Inc.
+Lam Research
 Landesbank Baden-Wurttemberg
+Land O'Lakes, Inc.
+La Poste
+Last.fm
+Lastfm
 Las Vegas Sands
 Las Vegas Sands Corp.
-Lastfm
-Last.fm
+L Brands, Inc.
+L Brands Inc.
 LDOS
 Lear Corporation
 Leaseweb
@@ -1004,8 +1008,8 @@ MDLZ
 MeadWestvaco Corporation
 Medco Health Solutions
 Medipal Holdings
-Medtronic plc
 Medtronic, Inc.
+Medtronic plc
 Meiji Yasuda Life Insurance
 Merck
 Merck & Co.
@@ -1048,9 +1052,10 @@ Mondoo
 Monsanto Company
 Monster Beverage
 Moody's Corp
+Moovit
 Morgan Stanley
-Motorola Solutions Inc.
 Motorola Solutions, Inc.
+Motorola Solutions Inc.
 Mouseflow
 Mozilla
 Mozilla Corporation
@@ -1072,8 +1077,8 @@ Nasdaq
 Nasdaq, Inc.
 National Australia Bank
 National Grid
-National Oilwell Varco Inc.
 National Oilwell Varco, Inc.
+National Oilwell Varco Inc.
 Nationwide
 Nationwide Mutual Insurance Co.
 Navistar International Corporation
@@ -1086,8 +1091,6 @@ NetApp
 NetApp, Inc.
 Netflix Inc.
 Netlify
-New York Life Insurance
-New York Life Insurance Company
 Newell Brands
 Newell Rubbermaid Inc.
 Newmont Corporation
@@ -1095,6 +1098,8 @@ Newmont Mining Corporation
 News Corp.
 News Corp. Class A
 News Corp. Class B
+New York Life Insurance
+New York Life Insurance Company
 NextEra Energy
 NextEra Energy, Inc.
 NFLX
@@ -1175,8 +1180,8 @@ Otechie
 OTIS
 Otis Worldwide
 Owens & Minor, Inc.
-Owens Corning
 Owens-Illinois, Inc.
+Owens Corning
 Ozon Group
 PACCAR Inc
 PACCAR Inc.
@@ -1184,6 +1189,7 @@ Pacific Life
 Packaging Corporation of America
 Palantir Technologies
 Panasonic
+Papaki
 Parker-Hannifin
 Parker-Hannifin Corporation
 Patreon
@@ -1275,8 +1281,8 @@ QRVO
 QUALCOMM Inc.
 Qualcomm Incorporated
 Quanta Computer
-Quanta Services Inc.
 Quanta Services, Inc.
+Quanta Services Inc.
 Quest Diagnostics
 Quest Diagnostics Incorporated
 Quintiles Transnational Holdings Inc.
@@ -1294,8 +1300,8 @@ RBS
 Reaktor
 Realogy Holdings Corp.
 Realty Income Corporation
-Red Hat, Inc.
 Reddit, Inc.
+Red Hat, Inc.
 Regency Centers Corporation
 Regeneron Pharmaceuticals
 Regions Financial Corp.
@@ -1306,8 +1312,8 @@ Reliance Industries
 Reliance Steel & Aluminum Co.
 Renault
 Repsol YPF
-Republic Services Inc
 Republic Services, Inc.
+Republic Services Inc
 ResMed
 Responsys
 Reynolds American Inc.
@@ -1319,8 +1325,8 @@ Robert Bosch
 Robert Half International
 Roche Group
 Rock-Tenn Company
-Rockwell Automation Inc.
 Rockwell Automation, Inc.
+Rockwell Automation Inc.
 Rollins Inc.
 Roper Technologies
 Rosneft Oil
@@ -1336,8 +1342,8 @@ Royal Philips Electronics
 Ruuvi Innovations Ltd
 RWE
 Ryder System, Inc.
-S-Oil
 S&P Global, Inc.
+S-Oil
 Sabic
 Safeway
 Safeway Inc.
@@ -1349,8 +1355,8 @@ Samsung Electronics
 SanDisk Corporation
 Sanmina
 Sanofi
-SBA Communications
 SBAC
+SBA Communications
 Sberbank
 SBUX
 Schlumberger
@@ -1378,8 +1384,8 @@ Shougang Group
 Showa Shell Sekiyu
 SHV Holdings
 Siemens
-Simon Property Group Inc
 Simon Property Group, Inc.
+Simon Property Group Inc
 SinnerSchrader Deutschland GmbH
 Sinochem Group
 Sinomach
@@ -1442,8 +1448,8 @@ Sumitomo Chemical
 Sumitomo Electric Industries
 Sumitomo Life Insurance
 Sumitomo Mitsui Financial Group
-Sun Life Financial
 Suncor Energy
+Sun Life Financial
 Sunoco
 SunTrust Banks, Inc.
 Superfeedr
@@ -1455,8 +1461,8 @@ Susser Holdings Corporation
 Suzuken
 Suzuki Motor
 SVB Financial
-Swiss Re
 Swisscom
+Swiss Re
 SWKS
 Swyftx
 Symantec Corporation
@@ -1467,10 +1473,10 @@ Synopsys Inc.
 Sysco
 Sysco Corp.
 Sysco Corporation
+T&D Holdings
 T-Mobile
 T-Mobile US
 T. Rowe Price Group
-T&D Holdings
 Take-Two Interactive
 Tapestry, Inc.
 Targa Resources Corp.
@@ -1478,12 +1484,12 @@ Target
 Target Corp.
 Tata Motors
 Tata Steel
-TE Connectivity
-TE Connectivity Ltd.
 Tech Data
 Tech Data Corporation
-TechRadar
 TechnipFMC
+TechRadar
+TE Connectivity
+TE Connectivity Ltd.
 Telecom Italia
 Teledyne Technologies
 Teleflex
@@ -1526,16 +1532,16 @@ The Pantry, Inc.
 The PNC Financial Services Group, Inc.
 The Priceline Group Inc.
 The Progressive Corporation
+Thermo Fisher Scientific
+Thermo Fisher Scientific Inc.
 The Sherwin-Williams Company
 The Southern Company
 The TJX Companies, Inc.
-The Travelers Companies Inc.
 The Travelers Companies, Inc.
+The Travelers Companies Inc.
 The Walt Disney Company
 The Western Union Company
 The Williams Companies, Inc.
-Thermo Fisher Scientific
-Thermo Fisher Scientific Inc.
 Thrivent Financial for Lutherans
 ThyssenKrupp
 TIAA-CREF
@@ -1599,6 +1605,8 @@ Union Pacific Corporation
 United Airlines Holdings
 United Continental Holdings
 United Continental Holdings, Inc.
+UnitedHealth Group
+UnitedHealth Group Inc.
 United Natural Foods, Inc.
 United Parcel Service
 United Rentals, Inc.
@@ -1606,8 +1614,6 @@ United Services Automobile Association
 United States Steel Corporation
 United Stationers Inc.
 United Technologies
-UnitedHealth Group
-UnitedHealth Group Inc.
 Universal Health Services
 Universal Health Services, Inc.
 Universiteit Gent
@@ -1627,15 +1633,16 @@ Veikkaus Oy
 Ventas Inc
 Veolia Environnement
 Verdaccio
-Verisign Inc.
 Verisign, Inc.
+Verisign Inc.
 Verisk Analytics
 Verizon Communications
 Vertex Pharmaceuticals Inc
 VF Corporation
 VIAC
-Viacom Inc.
 ViacomCBS
+Viacom Inc.
+Viber
 Vimeo, Inc.
 Vinci
 Vincit
@@ -1661,9 +1668,10 @@ Walgreen Co.
 Walgreens Boots Alliance
 Walmart
 Walt Disney
-Waste Management Inc.
 Waste Management, Inc.
+Waste Management Inc.
 Waters Corporation
+Waze
 WEC Energy Group
 WELL
 WellCare Health Plans, Inc.
@@ -1672,13 +1680,13 @@ Wells Fargo
 Welltower Inc.
 WESCO International, Inc.
 Wesfarmers
-West Pharmaceutical Services
 Western Digital
 Western Digital Corporation
 Western Refining, Inc.
 Western Union Co
 Westinghouse Air Brake Technologies Corp
 Westpac Banking
+West Pharmaceutical Services
 WestRock
 Weyerhaeuser
 Weyerhaeuser Company
@@ -1701,8 +1709,8 @@ World Fuel Services Corporation
 Wuhan Iron & Steel
 Wyndham Worldwide Corporation
 WYNN
-Wynn Resorts Ltd
 Wynn Resorts, Limited
+Wynn Resorts Ltd
 Xbox
 Xcel Energy Inc.
 Xerox


### PR DESCRIPTION
# Fix Dictionary

Dictionary: ```companies```

## Description
Adds missing words to companies
* viber
* waze
* imgix
* moovit
* cdnjs
* hulu
* papaki
* imessage

Fixes word order
## References

https://github.com/streetsidesoftware/cspell-dicts/issues/1897

## Checklist

- [X] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
