### PR TITLE
fix: Adds missing words to `software-services`

### DIFF
--- a/dictionaries/software-terms/src/software-services.txt
+++ b/dictionaries/software-terms/src/software-services.txt
@@ -1,3 +1,4 @@
 Appointedd
 Calendly
+imessage
 Todoist


### PR DESCRIPTION
# Fix Dictionary

Dictionary: ```software-services```

## Description

Adds  Missing word

* imessage

## References

https://github.com/streetsidesoftware/cspell-dicts/issues/1897
https://github.com/streetsidesoftware/cspell-dicts/pull/1938

## Checklist

- [X] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
