### PR TITLE
Add "LTSC" and "Nanoserver" to win32 dictionary

### DIFF
--- a/dictionaries/win32/src/win32.txt
+++ b/dictionaries/win32/src/win32.txt
@@ -25531,6 +25531,7 @@ LTRDATE
 LTRIGGER
 LTRIM
 LTRREADING
+LTSC
 LTSH
 LTUP
 LUAENABLED
@@ -30904,6 +30905,7 @@ Namespaces
 Naming
 Nanosecond
 Nanoseconds
+Nanoserver
 Narrow
 National
 Native


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: win32

## Description

Add "LTSC" and "Nanoserver." Both terms appear in the container names of Windows base images.

LTSC stands for Long-Term Servicing Channel.
Nanoserver is the name of a Windows container base image.

## References

- https://learn.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/container-base-images

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
