### PR TITLE
fix: Add "pyright" to Python dictionary

### DIFF
--- a/dictionaries/python/src/python/python.txt
+++ b/dictionaries/python/src/python/python.txt
@@ -636,6 +636,7 @@ pylint
 pypi
 pyproject
 pypy
+pyright
 pytest
 pyyaml
 queue


### PR DESCRIPTION
Pyright is a static type checker for Python.

# Add/Fix Dictionary

Dictionary: Python

## Description

Add "pyright."

## References

- https://github.com/microsoft/pyright

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
