### PR TITLE
fix: Correct the spelling of successful in the dotnet dict

### DIFF
--- a/dictionaries/dotnet/dict/dotnet.txt
+++ b/dictionaries/dotnet/dict/dotnet.txt
@@ -2178,7 +2178,7 @@ subtitle
 subtree
 subtype
 success
-successfull
+successful
 such
 suffix
 suggested


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: dotnet

## Description

The word "successful" was mistakenly spelled as "successfull"


## References

N/A

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
