### PR TITLE
feat: Enable "sql" in VS Code by default

### DIFF
--- a/dictionaries/sql/cspell-ext.json
+++ b/dictionaries/sql/cspell-ext.json
@@ -31,5 +31,6 @@
             "ignoreRegExpList": ["sql-hex-number", "sql-unicode-string-prefix"],
             "dictionaryDefinitions": []
         }
-    ]
+    ],
+    "enableFiletypes": ["sql"]
 }

--- a/dictionaries/sql/cspell.json
+++ b/dictionaries/sql/cspell.json
@@ -8,6 +8,5 @@
             "dictionaries": ["sql"]
         }
     ],
-    "enableFiletypes": ["sql"],
     "import": ["./cspell-ext.json"]
 }


### PR DESCRIPTION
Related to https://github.com/streetsidesoftware/vscode-spell-checker/issues/2576