### PR TITLE
Fix: Add "arbitrary(-ies)" to software terms dictionary

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -46,6 +46,8 @@ app
 append
 appid
 approximant
+arbitrary
+arbitraries
 arborescence
 arccosine
 architected


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: software terms

## Description

Add "arbitrary" and "arbitraries." In property-based testing, arbitraries generate random input values.

## References

- https://hackage.haskell.org/package/QuickCheck-2.14.2/docs/Test-QuickCheck-Arbitrary.html
- https://github.com/dubzzz/fast-check/blob/main/packages/fast-check/documentation/Arbitraries.md

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
