### PR TITLE
fix: Add "Ruff" and "Tomli" to Python dictionary

### DIFF
--- a/dictionaries/python/src/python/python.txt
+++ b/dictionaries/python/src/python/python.txt
@@ -679,6 +679,7 @@ round
 rpartition
 rsplit
 rstrip
+Ruff
 runpy
 RuntimeError
 RuntimeWarning
@@ -784,6 +785,7 @@ tix
 tkinter
 token
 tokenize
+Tomli
 tool
 trace
 traceback


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: Python

## Description

Ruff is a Python linter, and Tomli is a package for working with toml files.

## References

- [Ruff](https://github.com/charliermarsh/ruff)
- [Tomli](https://github.com/hukkin/tomli)

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
