### PR TITLE
Add shortdoc to elixir.txt

### DIFF
--- a/dictionaries/elixir/dict/elixir.txt
+++ b/dictionaries/elixir/dict/elixir.txt
@@ -120,6 +120,7 @@ rebar
 regex
 reraise
 selfsigned
+shortdoc
 sobelow
 space
 specdiff

--- a/dictionaries/elixir/src/elixir.txt
+++ b/dictionaries/elixir/src/elixir.txt
@@ -116,6 +116,7 @@ rebar
 regex
 reraise
 selfsigned
+shortdoc
 sobelow
 space
 specdiff


### PR DESCRIPTION
shortdoc is how you add docs to Mix tasks in Elixir

## References
https://hexdocs.pm/mix/1.14/Mix.Task.html