### PR TITLE
Add missing truetype & opentype

### DIFF
--- a/dictionaries/css/src/css.txt
+++ b/dictionaries/css/src/css.txt
@@ -691,6 +691,7 @@ on
 only
 opacity
 open
+opentype
 operator
 optgroup
 optimize
@@ -1056,6 +1057,7 @@ treeview
 triangle
 trim
 true
+truetype
 tty
 turn
 turquoise


### PR DESCRIPTION
Basically #416, but ported to the CSS dictionary.

<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: css

## Description

Add missing truetype & opentype - basically #416 but ported to the CSS dictionary

## References

- issue 416

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
