### PR TITLE
fix: Add `benchmarker` to software-terms.txt

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -1694,3 +1694,5 @@ zip
 zlib
 ZPool
 ZPools
+npmrc
+benchmarker


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: `npmrc/benchmarker`

## Description

`npmrc`: It is the configuration file for npm.

`benchmarker`: Refers to the benchmarking tool.

## References

- none

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
