### PR TITLE
add avatar of Contributors on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ Please help correct any mistakes in the dictionaries.
 
 See: [Contributing](CONTRIBUTING.md)
 
+Thanks so much to all of our amazing contributors!
+
+<a href="https://github.com/streetsidesoftware/cspell-dicts/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=streetsidesoftware/cspell-dicts&r="  width="800px"/>
+</a>
+
 ## How to create a new dictionary
 
 Please fork this repository to add new dictionaries.


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _dictionary_

## Description

add avatar of Contributors on README.md
I think this's an honor for the contributor

As shown
![图片](https://user-images.githubusercontent.com/55081697/235091230-fa7ddc6d-1e1e-4b41-82b6-62e205312b5f.png)

## References

- _Any source references._

## Checklist

- [ ] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
