### PR TITLE
fix: Add "ariakit" to the software tools dict

### DIFF
--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -11,6 +11,7 @@ Ansible
 Antergos
 Apparmor
 Appveyor
+ariakit
 Artifactory
 asdf
 Atlaskit


### PR DESCRIPTION
[Ariakit](https://ariakit.org/) is an open source library of accessible React components and hooks.
