### PR TITLE
fix: add seaborn Ethr cygwin psping sockperf to software-tools.txt

### DIFF
--- a/dictionaries/data-science/src/data-science-tools.txt
+++ b/dictionaries/data-science/src/data-science-tools.txt
@@ -1,3 +1,4 @@
 # Data Science Related tools
 Databricks
 Pytorch
+seaborn

--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -230,7 +230,6 @@ ZeroMQ
 zsh
 Zuul
 Zypper
-seaborn
 Ethr
 cygwin
 pspings

--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -230,3 +230,8 @@ ZeroMQ
 zsh
 Zuul
 Zypper
+seaborn
+Ethr
+cygwin
+pspings
+sockperf


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: software-tools.txt

## Description

add seaborn Ethr cygwin psping sockperf to software-tools.txt
detail info
 modified:   dictionaries/software-terms/src/software-tools.txt


## References

seaborn  https://seaborn.pydata.org/
Ethr     https://github.com/microsoft/ethr
cygwin   https://www.cygwin.com/
psping   https://learn.microsoft.com/en-us/sysinternals/downloads/psping
sockperf https://github.com/Mellanox/sockperf 

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
