### PR TITLE
fix: Fix Norwegian Bokmål link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Various [cspell](https://github.com/streetsidesoftware/cspell) dictionaries. Eac
 - [Greek](dictionaries/el)
 - [Hebrew](dictionaries/he)
 - [Italian](dictionaries/it_IT)
-- [Norwegian Bokmål](dictionaries/no_NB)
+- [Norwegian Bokmål](dictionaries/nb_NO)
 - [Persian](dictionaries/fa_IR)
 - [Polish](dictionaries/pl_PL)
 - [Portuguese - Brazilian](dictionaries/pt_BR)


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

## Description

Change Norwegian Bokmål link in README from `no_NB` to `nb_NO`

## Checklist

- [X] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
