### PR TITLE
fix: add words to common_packages

### DIFF
--- a/dictionaries/python/src/common_packages.txt
+++ b/dictionaries/python/src/common_packages.txt
@@ -1,1 +1,8 @@
 # Common Packages and Exports
+matplotlib.pyplot
+torch.dequantize
+optim.Adadelta
+picklable
+slurm
+sigterm
+Scapy


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: common_packages.txt

## Description

add words to common_packages.txt
detail add 
matplotlib.pyplot
torch.dequantize
optim.Adadelta
picklable
slurm
sigterm
Scapy

## References

matplotlib.pyplot: is a library used for creating graphical interfaces, providing multiple methods for creating plots, scatter plots, histograms, etc.
torch.dequantize: is a library used for restoring quantized data to its original form, offering efficient quantization data restoration algorithms.
optim.Adadelta: is a library used for optimizing neural network parameters, employing adaptive learning rate algorithms.
picklable: is a library used forSerializing Python objects to byte streams, widely used in scientific computing and data exchange.
slurm: is a library used for distributed computing, providing tools for running computing tasks in distributed computing environments.
sigterm: is a library used for handling signal events, offering methods for handling signals during program execution.
Scapy: is a library used for network data collection and analysis, providing multiple methods for collecting network data packets and analyzing them.

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
