### PR TITLE
add SATA Roadmap to software-terms.txt

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -1711,3 +1711,5 @@ zip
 zlib
 ZPool
 ZPools
+SATA 
+Roadmap


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: software-terms.txt

## Description

add SATA Roadmap to software-terms.txt

## References

SATA   Serial Advanced Technology Attachment (SATA SSD)
Roadmap (Roadmap is a term that has increasingly been used in project management to refer to a plan or timeline that outlines the steps and milestones needed to achieve a specific goal or objective. 
It is often used to visualize the path forward and help teams and organizations stay on track and make adjustments as needed.)


## Checklist

- [ ] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
