### PR TITLE
fix: add  linkcss to npm.txt

### DIFF
--- a/dictionaries/npm/src/npm.txt
+++ b/dictionaries/npm/src/npm.txt
@@ -720,3 +720,4 @@ yauzl
 yo
 zmq
 zombie
+linkcss


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: npm.txt

## Description
add linkcss to npm.txt


## References


LinkCSS: LinkCSS is a responsive and functional CSS framework that uses Web Components and Shadow DOM technology to make it easier for developers to build complex web applications. LinkCSS also originates from an open-source project on GitHub, created and maintained by developer Zhao Wanghu. The project's address is: https://github.com/linkcss/linkcss.

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
