### PR TITLE
Added two words in php, Laravel & Laragon

### DIFF
--- a/dictionaries/php/src/allowed-terms.txt
+++ b/dictionaries/php/src/allowed-terms.txt
@@ -187,6 +187,8 @@ kadm
 keygen
 keypress
 langinfo
+Laravel
+Laragon
 len
 lf
 linefeed


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add Dictionary

Dictionary: PHP

## Description

Added two wards in PHP dictionary

## References

- [Laravel, a PHP framework](https://laravel.com/)
- [Laragon, a PHP stack local environment management](https://laragon.org/)

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
