### PR TITLE
fix: Add `srgb` to css

### DIFF
--- a/dictionaries/css/src/css.txt
+++ b/dictionaries/css/src/css.txt
@@ -951,6 +951,7 @@ spread
 springgreen
 square
 src
+srgb
 stacking
 standard
 start


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: srgb'
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: css

## Description

Add the new `srgb` value

## References

- [color-mix()](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix)

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
