### PR TITLE
fix: add "crafter" to en_shared

### DIFF
--- a/dictionaries/en_shared/src/shared-additional-words.txt
+++ b/dictionaries/en_shared/src/shared-additional-words.txt
@@ -12,6 +12,7 @@ cellpadding
 Christoph
 conformant
 COVID
+crafter
 dropshipper
 dropshippers
 dropshipping


### PR DESCRIPTION
Closes #2430

<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: en_shared

## Description

Crafter is a word but not yet recognized as one by spell.

## References

- https://scrabble.merriam.com/finder/crafter
- https://en.m.wiktionary.org/wiki/crafter
- https://dictionary.cambridge.org/us/dictionary/english/crafter

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
