### PR TITLE
chore: Add definition to Trie in create-dictionary

### DIFF
--- a/generator-cspell-dicts/generators/app/index.js
+++ b/generator-cspell-dicts/generators/app/index.js
@@ -77,7 +77,7 @@ module.exports = class extends Generator {
             {
                 type: 'confirm',
                 name: 'useTrie',
-                message: 'Store as Trie',
+                message: 'Store as Trie: Mainly used for natural language dictionaries to store their large sizes.',
                 default: (props) => ['.dic', '.aff'].includes(path.extname(props.srcFile)),
             },
             {


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: NA

## Description

Add definition to trie. 
![image](https://github.com/streetsidesoftware/cspell-dicts/assets/32241933/4721c339-f13e-48bb-8ade-f15cdbc0f26b)


Closes #2386 

## References

NA

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
