### PR TITLE
chore: Improve install reliability

### DIFF
--- a/dictionaries/ada/package.json
+++ b/dictionaries/ada/package.json
@@ -16,7 +16,7 @@
     "test-dict": "shx head -n 100 src/ada.txt | cspell -v -c ./cspell-ext.json --local=* --languageId=ada stdin",
     "test-samples": "cspell \"samples/**\"",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/al/package.json
+++ b/dictionaries/al/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build",
     "test": "shx head -n 1000 \"src/al.txt\" | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=AL\" stdin",
     "prepublishOnly": "echo OK",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/ar/package.json
+++ b/dictionaries/ar/package.json
@@ -20,7 +20,7 @@
     "test-samples": "cspell -v -c ./cspell-ext.json --local=ar,en \"samples/**\"",
     "test": "pnpm run test-ar && pnpm run test-samples",
     "sync": "bash ./scripts/sync.sh && pnpm lint",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "pnpm run conditional-build && pnpm test"
   },
   "repository": {

--- a/dictionaries/aws/package.json
+++ b/dictionaries/aws/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli compile --keep-raw-case --use-legacy-splitter src/aws.txt --no-compress -o ./dict",
     "test": "head -n 100 src/aws.txt | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=aws\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/bash/package.json
+++ b/dictionaries/bash/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build",
     "test": "shx head -n 100 src/bash-words.txt | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=shellscript\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/bg_BG/package.json
+++ b/dictionaries/bg_BG/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build && pnpm run gz",
     "build:conditional": "cspell-tools-cli build --conditional && pnpm gz",
     "test": "hunspell-reader words -n 1000 \"src/bg_BG.dic\" | cspell -v -c ./cspell-ext.json \"--local=bg\" \"--languageId=*\" stdin",
-    "prepare": "pnpm run gz",
+    "prepare:dictionary": "pnpm run gz",
     "gz": "cspell-tools-cli gzip \"dict/*.trie\"",
     "prepublishOnly": "echo pre-publish"
   },

--- a/dictionaries/ca/package.json
+++ b/dictionaries/ca/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build && pnpm prepare",
     "build:conditional": "cspell-tools-cli build --conditional && pnpm gz",
     "test": "hunspell-reader words -n 1000 \"src/ca.dic\" | cspell -v -c ./cspell-ext.json --local=ca --languageId=* stdin",
-    "prepare": "pnpm run gz",
+    "prepare:dictionary": "pnpm run gz",
     "gz": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "echo pre-publish"
   },

--- a/dictionaries/city-names-finland/package.json
+++ b/dictionaries/city-names-finland/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli compile --keep-raw-case --use-legacy-splitter src/city-names-finland.txt --no-compress -o ./dict",
     "test": "shx head -n 100 src/city-names-finland.txt | cspell -v -c ./cspell-ext.json --local=* --languageId=* stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/clojure/package.json
+++ b/dictionaries/clojure/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build",
     "test": "shx head -n 1000 \"src/clojure.txt\" | cspell -v -c ./cspell-ext.json \"--local=en\" \"--languageId=clojure\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/companies/package.json
+++ b/dictionaries/companies/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli compile --no-compress --split \"src/companies.txt\" -o ./dict",
     "test": "shx cat \"src/companies.txt\" | cspell -v -c ./cspell-ext.json --local=* --languageId=* stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/cpp/package.json
+++ b/dictionaries/cpp/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build",
     "test": "shx head -n 1000 \"src/cpp.txt\" | cspell -v -c ./cspell-ext.json --local=* --languageId=cpp stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/cryptocurrencies/package.json
+++ b/dictionaries/cryptocurrencies/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build",
     "test": "cspell samples --no-progress",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/cs_CZ/package.json
+++ b/dictionaries/cs_CZ/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "cspell-tools-cli build && pnpm prepare",
     "test": "hunspell-reader words -n 1000 src/Czech.dic | cspell -v -c ./cspell-ext.json --local=cs --languageId=* stdin",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "echo pre-publish"
   },
   "repository": {

--- a/dictionaries/csharp/package.json
+++ b/dictionaries/csharp/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli compile --split \"csharp.txt\" -o .",
     "test": "shx head -n 100 \"csharp.txt\" | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=csharp\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/css/package.json
+++ b/dictionaries/css/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli compile --keep-raw-case src/css.txt --no-compress -o ./dict",
     "test": "shx head -n 100 src/css.txt | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=css\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/da_DK/package.json
+++ b/dictionaries/da_DK/package.json
@@ -19,7 +19,7 @@
     "test-de": "hunspell-reader words -n 1000 \"src/hunspell/index.dic\" | cspell -v -c ./cspell-ext.json --local=da-DK --languageId=* stdin",
     "test-samples": "cspell -c ./cspell-ext.json --local=da-dk,en \"samples/**\"",
     "test": "pnpm run test-de && pnpm run test-samples",
-    "prepare": "echo ok",
+    "prepare:dictionary": "echo ok",
     "prepublishOnly": "pnpm run conditional-build"
   },
   "repository": {

--- a/dictionaries/dart/package.json
+++ b/dictionaries/dart/package.json
@@ -16,7 +16,7 @@
     "test-samples": "cspell \"samples/**/*.dart\"",
     "test-dict": "shx head -n 1000 \"src/dart.txt\" | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=dart\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/data-science/package.json
+++ b/dictionaries/data-science/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build",
     "test": "cspell -c ./cspell-ext.json samples",
     "prepublishOnly": "echo OK",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/de_AT/package.json
+++ b/dictionaries/de_AT/package.json
@@ -19,7 +19,7 @@
     "test-de": "hunspell-reader words -n 1000 \"src/hunspell/index.dic\" | cspell -v -c ./cspell-ext.json --local=de-AT --languageId=* stdin",
     "test-samples": "cspell -v -c ./cspell-ext.json --local=de-at,en \"samples/**\"",
     "test": "pnpm run test-de && pnpm run test-samples",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "pnpm run conditional-build && pnpm test"
   },
   "repository": {

--- a/dictionaries/de_CH/package.json
+++ b/dictionaries/de_CH/package.json
@@ -19,7 +19,7 @@
     "test-de": "hunspell-reader words -n 1000 \"src/hunspell/index.dic\" | cspell -v -c ./cspell-ext.json --local=de --languageId=* stdin",
     "test-samples": "cspell -v -c ./cspell-ext.json --local=de,en \"samples/**\"",
     "test": "pnpm run test-de && pnpm run test-samples",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "pnpm run conditional-build && pnpm test"
   },
   "repository": {

--- a/dictionaries/de_DE/package.json
+++ b/dictionaries/de_DE/package.json
@@ -20,7 +20,7 @@
     "test-de-old": "hunspell-reader words -n 1000 \"src/German_de_DE.dic\" | cspell -v -c ./cspell-ext.json --local=de --languageId=* stdin",
     "test-samples": "cspell -v -c ./cspell-ext.json --local=de,en \"samples/**\"",
     "test": "pnpm run test-de && pnpm run test-samples && pnpm run test-de-old",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "pnpm run conditional-build && pnpm test"
   },
   "scriptsX": {

--- a/dictionaries/django/package.json
+++ b/dictionaries/django/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli compile --keep-raw-case \"src/*.txt\" -M django --no-compress -o ./dict",
     "test": "shx head -n 100 src/django.txt | cspell -v -c ./cspell-ext.json --local=* --languageId=python stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/docker/package.json
+++ b/dictionaries/docker/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build",
     "test": "shx head -n 1000 \"src/docker-words.txt\" | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=dockerfile\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/dotnet/package.json
+++ b/dictionaries/dotnet/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build",
     "test": "shx head -n 100 src/dotnet.txt | cspell -v -c ./cspell-ext.json --local=* --languageId=cs stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/el/package.json
+++ b/dictionaries/el/package.json
@@ -20,7 +20,7 @@
     "checksum": "cspell-tools-cli shasum -c checksum.txt",
     "conditional-build": "pnpm run --silent checksum || pnpm run build",
     "gen-checksum": "cspell-tools-cli shasum -u checksum.txt --list-file source-files.txt source-dependencies.txt",
-    "prepare": "pnpm run build:gz",
+    "prepare:dictionary": "pnpm run build:gz",
     "test": "shx head -n 1000 ./src/Greek.txt | cspell -v -c cspell-ext.json --local=el stdin"
   },
   "repository": {

--- a/dictionaries/elixir/package.json
+++ b/dictionaries/elixir/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli compile --keep-raw-case src/elixir.txt --no-compress -o ./dict",
     "test": "shx head -n 100 src/elixir.txt | cspell -v -c ./cspell-ext.json --local=* --languageId=elixir stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/en-common-misspellings/package.json
+++ b/dictionaries/en-common-misspellings/package.json
@@ -14,7 +14,7 @@
     "build": "echo ok",
     "test": "cspell .",
     "prepublishOnly": "echo OK",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/en_AU/package.json
+++ b/dictionaries/en_AU/package.json
@@ -18,7 +18,7 @@
     "compile": "cspell-tools-cli build && pnpm run gen-checksum",
     "conditional-build": "pnpm run sync && pnpm run --silent checksum || pnpm run build",
     "gen-checksum": "cspell-tools-cli shasum -u checksum.txt --list-file source-files.txt source-dependencies.txt",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "echo pre-publish",
     "test-text": "cspell -v -c ./cspell-ext.json --local=en-au --languageId=* \"tests/*.txt\"",
     "test": "pnpm run test-text"

--- a/dictionaries/en_CA/package.json
+++ b/dictionaries/en_CA/package.json
@@ -18,7 +18,7 @@
     "compile": "cspell-tools-cli build && pnpm run gen-checksum",
     "conditional-build": "pnpm run sync && pnpm run --silent checksum || pnpm run build",
     "gen-checksum": "cspell-tools-cli shasum -u checksum.txt --list-file source-files.txt source-dependencies.txt",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "echo pre-publish",
     "test-text": "cspell -v -c ./cspell-ext.json --local=en-ca --languageId=* \"tests/*.txt\"",
     "test": "pnpm run test-text"

--- a/dictionaries/en_GB-MIT/package.json
+++ b/dictionaries/en_GB-MIT/package.json
@@ -16,7 +16,7 @@
     "compile": "cspell-tools-cli build && pnpm run gen-checksum",
     "conditional-build": "pnpm run --silent checksum || pnpm run build",
     "gen-checksum": "cspell-tools-cli shasum -u checksum.txt --list-file source-files.txt source-dependencies.txt",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "echo pre-publish",
     "test-dict": "shx head -n 1000 \"./src/wordsEnGb.txt\" | cspell -v -c ./cspell-ext.json --local=en_gb --languageId=* stdin",
     "test-text": "cspell -v -c ./cspell-ext.json --local=en_gb --languageId=* \"tests/*.txt\"",

--- a/dictionaries/en_GB/package.json
+++ b/dictionaries/en_GB/package.json
@@ -17,7 +17,7 @@
     "checksum": "cspell-tools-cli shasum -c checksum.txt",
     "conditional-build": "pnpm run sync && pnpm run --silent checksum || pnpm run build",
     "gen-checksum": "cspell-tools-cli shasum -u checksum.txt --list-file source-files.txt source-dependencies.txt",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "echo pre-publish",
     "test-dict": "shx head -n 1000 \"./src/wordsEnGb.txt\" | cspell -v -c ./cspell-ext.json --local=en_gb --languageId=* stdin",
     "test-text": "cspell -v -c ./cspell-ext.json --local=en_gb --languageId=* \"tests/*.txt\"",

--- a/dictionaries/en_US/package.json
+++ b/dictionaries/en_US/package.json
@@ -20,7 +20,7 @@
     "test-text": "cspell -v -c ./cspell-ext.json --local=en --languageId=* \"tests/*.txt\"",
     "gen-checksum": "cspell-tools-cli shasum -u checksum.txt --list-file source-files.txt source-dependencies.txt",
     "test": "pnpm run test-dict && pnpm run test-text",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "echo pre-publish"
   },
   "repository": {

--- a/dictionaries/en_shared/package.json
+++ b/dictionaries/en_shared/package.json
@@ -15,7 +15,7 @@
     "build": "cspell-tools-cli build",
     "test": "shx head -n 1000 \"src/shared-additional-words.txt\" | cspell -v -c ./cspell-ext.json \"--local=en\" \"--languageId=*\" stdin",
     "prepublishOnly": "echo OK",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/eo/package.json
+++ b/dictionaries/eo/package.json
@@ -17,7 +17,7 @@
     "test:samples": "cspell samples",
     "test": "pnpm test:dic && pnpm test:samples",
     "gz": "cspell-tools-cli gzip \"*.trie\"",
-    "prepare": "pnpm gz",
+    "prepare:dictionary": "pnpm gz",
     "prepublishOnly": "echo pre-publish"
   },
   "repository": {

--- a/dictionaries/es_ES/package.json
+++ b/dictionaries/es_ES/package.json
@@ -22,7 +22,7 @@
     "test-dict": "hunspell-reader words -n 1000 \"src/hunspell/index.dic\" | cspell -v -c ./cspell-ext.json --local=es --languageId=* stdin",
     "test-text": "cspell",
     "test": "pnpm run test-dict && pnpm run test-text",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "echo pre-publish"
   },
   "repository": {

--- a/dictionaries/et-EE/package.json
+++ b/dictionaries/et-EE/package.json
@@ -21,7 +21,7 @@
     "test-text": "cspell -v -c ./cspell-ext.json --local=et --languageId=* \"samples/**\"",
     "gen-checksum": "cspell-tools-cli shasum -u checksum.txt --list-file source-files.txt source-dependencies.txt",
     "test": "pnpm run test-dict && pnpm run test-text",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "echo pre-publish"
   },
   "repository": {

--- a/dictionaries/eu/package.json
+++ b/dictionaries/eu/package.json
@@ -18,7 +18,7 @@
     "test": "hunspell-reader words -n 1000 -m 1 \"src/eu.dic\" | cspell -v -c ./cspell-ext.json \"--local=eu\" \"--languageId=*\" stdin",
     "gen-checksum": "cspell-tools-cli shasum -u checksum.txt --list-file source-dependencies.txt",
     "prepublishOnly": "echo OK",
-    "prepare": "echo OK"
+    "prepare:dictionary": "echo OK"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/fa_IR/package.json
+++ b/dictionaries/fa_IR/package.json
@@ -16,7 +16,7 @@
     "gz": "cspell-tools-cli gzip \"*.trie\"",
     "test": "cspell samples --no-progress",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm gz"
+    "prepare:dictionary": "pnpm gz"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/filetypes/package.json
+++ b/dictionaries/filetypes/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli compile \"filetypes.txt\" -o .",
     "test": "shx cat \"filetypes.txt\" | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=*\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/fonts/package.json
+++ b/dictionaries/fonts/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli compile --keep-raw-case --use-legacy-splitter src/fonts.txt --no-compress -o ./dict",
     "test": "shx head -n 100 src/fonts.txt | cspell -v -c ./cspell.json \"--local=*\" \"--languageId=*\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/fr_FR/package.json
+++ b/dictionaries/fr_FR/package.json
@@ -16,7 +16,7 @@
     "compile": "cspell-tools-cli build && pnpm run gen-checksum",
     "conditional-build": "pnpm run --silent checksum || pnpm run build",
     "gen-checksum": "cspell-tools-cli shasum -u checksum.txt --list-file source-files.txt source-dependencies.txt",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "echo pre-publish",
     "test-dict": "hunspell-reader words -n 1000 \"./src/hunspell-french-dictionaries-v7.0/fr-classique.dic\" | cspell -v -c ./cspell-ext.json \"--local=fr\" \"--languageId=*\" stdin",
     "test-text": "cspell -v -c ./cspell-ext.json --local=fr --languageId=* \"samples/**\"",

--- a/dictionaries/fr_FR_90/package.json
+++ b/dictionaries/fr_FR_90/package.json
@@ -16,7 +16,7 @@
     "compile": "cspell-tools-cli build && pnpm run gen-checksum",
     "conditional-build": "pnpm run --silent checksum || pnpm run build",
     "gen-checksum": "cspell-tools-cli shasum -u checksum.txt --list-file source-files.txt source-dependencies.txt",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "echo pre-publish",
     "test-dict": "hunspell-reader words -n 1000 \"./src/hunspell-french-dictionaries-v7.0/fr-reforme1990.dic\" | cspell -v -c ./cspell-ext.json \"--local=fr\" \"--languageId=*\" stdin",
     "test-text": "cspell -v -c ./cspell-ext.json --local=fr --languageId=* \"samples/**\"",

--- a/dictionaries/fsharp/package.json
+++ b/dictionaries/fsharp/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build",
     "test": "cspell samples",
     "prepublishOnly": "echo OK",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/fullstack/package.json
+++ b/dictionaries/fullstack/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build",
     "test": "shx cat \"src/fullstack.txt\" | cspell -v -c ./cspell-ext.json --local=* --languageId=php stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/gaming-terms/package.json
+++ b/dictionaries/gaming-terms/package.json
@@ -14,7 +14,7 @@
     "build": "cross-env NODE_OPTIONS=--max_old_space_size=8192 cspell-tools-cli build",
     "test": "shx head -n 1000 \"src/gaming-terms.txt\" | cspell -v -c ./cspell.json stdin",
     "prepublishOnly": "echo OK",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/git/package.json
+++ b/dictionaries/git/package.json
@@ -14,7 +14,7 @@
     "build": "echo skip",
     "test": "echo skip",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/golang/package.json
+++ b/dictionaries/golang/package.json
@@ -16,7 +16,7 @@
     "build": "cspell-tools-cli build",
     "test": "shx head -n 100 src/go.txt | cspell -v -c ./cspell-ext.json --local=* --languageId=go stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/haskell/package.json
+++ b/dictionaries/haskell/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli compile --keep-raw-case src/haskell.txt --no-compress -o ./dict",
     "test": "shx head -n 100 src/haskell.txt | cspell -v -c ./cspell-ext.json --local=* --languageId=haskell stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/he/package.json
+++ b/dictionaries/he/package.json
@@ -15,7 +15,7 @@
     "build:conditional": "cspell-tools-cli build --conditional && pnpm gz",
     "test": "cspell samples",
     "gz": "cspell-tools-cli gzip \"*.trie\"",
-    "prepare": "pnpm gz",
+    "prepare:dictionary": "pnpm gz",
     "prepublishOnly": "echo pre-publish"
   },
   "repository": {

--- a/dictionaries/hr_HR/package.json
+++ b/dictionaries/hr_HR/package.json
@@ -16,7 +16,7 @@
     "gz": "cspell-tools-cli gzip \"dict/*.trie\"",
     "test": "cspell samples --no-progress",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm gz"
+    "prepare:dictionary": "pnpm gz"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/html-symbol-entities/package.json
+++ b/dictionaries/html-symbol-entities/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli compile \"entities.txt\" -o .",
     "test": "shx head -n 100 \"entities.txt\" | cspell -v -c ./cspell-ext.json --local=* --languageId=html stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/html/package.json
+++ b/dictionaries/html/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build",
     "test": "shx head -n 100 src/html.txt | cspell -v -c ./cspell-ext.json \"--local=*\" --language-id=html stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/java/package.json
+++ b/dictionaries/java/package.json
@@ -16,7 +16,7 @@
     "test-dict": "shx head -n 100 \"src/java.txt\" | cspell -v -c ./cspell-ext.json --local=* --languageId=java stdin",
     "test-check": "ava",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/k8s/package.json
+++ b/dictionaries/k8s/package.json
@@ -15,7 +15,7 @@
     "build": "cspell-tools-cli compile --keep-raw-case src/k8s.txt --no-compress -o ./dict",
     "test": "shx head -n 100 src/k8s.txt | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=yaml\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/latex/package.json
+++ b/dictionaries/latex/package.json
@@ -16,7 +16,7 @@
     "test-dict": "shx head -n 1000 src/latex.txt | cspell -v -c ./cspell-ext.json --local=* --languageId=latex stdin",
     "test-check": "ava",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/lorem-ipsum/package.json
+++ b/dictionaries/lorem-ipsum/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build",
     "test": "shx head -n 1000 src/dictionary.txt | cspell -v -c ./cspell-ext.json --local=lorem --languageId=* stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/lt_LT/package.json
+++ b/dictionaries/lt_LT/package.json
@@ -15,7 +15,7 @@
     "build:conditional": "cspell-tools-cli build --conditional && pnpm gz",
     "gz": "cspell-tools-cli gzip \"*.trie\"",
     "test": "cspell samples --no-progress",
-    "prepare": "pnpm gz",
+    "prepare:dictionary": "pnpm gz",
     "prepublishOnly": "echo pre-publish"
   },
   "repository": {

--- a/dictionaries/lua/package.json
+++ b/dictionaries/lua/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli compile --keep-raw-case src/lua.txt --no-compress -o ./dict",
     "test": "shx head -n 1000 src/lua.txt | cspell -v -c ./cspell-ext.json --local=* --languageId=lua stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/markdown/package.json
+++ b/dictionaries/markdown/package.json
@@ -16,7 +16,7 @@
     "test-dict": "shx head -n 1000 \"src/markdown.txt\" | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=markdown\" stdin",
     "test-check": "ava",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/medicalterms/package.json
+++ b/dictionaries/medicalterms/package.json
@@ -15,7 +15,7 @@
     "build:conditional": "pnpm build --conditional",
     "test": "cspell samples --no-progress",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/mnemonics/package.json
+++ b/dictionaries/mnemonics/package.json
@@ -14,7 +14,7 @@
     "build": "cross-env NODE_OPTIONS=--max_old_space_size=8192 cspell-tools-cli compile --keep-raw-case --use-legacy-splitter src/mnemonics.txt --no-compress -o ./dict",
     "test": "shx head -n 1000 src/mnemonics.txt | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=cpp\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/monkeyc/package.json
+++ b/dictionaries/monkeyc/package.json
@@ -14,7 +14,7 @@
     "build": "cross-env NODE_OPTIONS=--max_old_space_size=8192 cspell-tools-cli compile \"src/monkeyc_keywords.txt\" -o .",
     "test": "shx head -n 1000 \"src/monkeyc_keywords.txt\" | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=monkeyc\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/nb_NO/package.json
+++ b/dictionaries/nb_NO/package.json
@@ -18,7 +18,7 @@
     "test-samples": "cspell \"samples/**\"",
     "test": "pnpm run test-words && pnpm run test-samples",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run gz"
+    "prepare:dictionary": "pnpm run gz"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/nl_NL/package.json
+++ b/dictionaries/nl_NL/package.json
@@ -23,7 +23,7 @@
     "test-dict": "hunspell-reader words -n 1000 \"src/hunspell/index.dic\" | cspell -v -c ./cspell-ext.json --local=nl --languageId=* stdin",
     "test-text": "cspell",
     "test": "pnpm run test-dict && pnpm run test-text",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "echo pre-publish"
   },
   "repository": {

--- a/dictionaries/node/package.json
+++ b/dictionaries/node/package.json
@@ -16,7 +16,7 @@
     "test": "pnpm test-dict",
     "test-dict": "shx cat \"node.txt\" | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=javascript\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/npm/package.json
+++ b/dictionaries/npm/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli compile --split \"src/npm.txt\" --no-compress -o ./dict -m npm",
     "test": "shx head -n 100 \"src/npm.txt\" | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=javascript\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/php/package.json
+++ b/dictionaries/php/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build",
     "test": "shx cat \"php.txt\" | cspell -v -c ./cspell-ext.json --local=* --languageId=php stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/pl_PL/package.json
+++ b/dictionaries/pl_PL/package.json
@@ -15,7 +15,7 @@
     "build": "cspell-tools-cli build && pnpm gz",
     "test": "cspell samples",
     "gz": "cspell-tools-cli gzip \"*.trie\"",
-    "prepare": "pnpm gz",
+    "prepare:dictionary": "pnpm gz",
     "prepublishOnly": "echo pre-publish"
   },
   "repository": {

--- a/dictionaries/powershell/package.json
+++ b/dictionaries/powershell/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build",
     "test": "shx head -n 100 src/powershell.txt | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=powershell\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/pt_BR/package.json
+++ b/dictionaries/pt_BR/package.json
@@ -20,7 +20,7 @@
     "test-dict": "hunspell-reader words -n 1000 \"src/hunspell/index.dic\" | cspell -v -c ./cspell-ext.json --local=pt --languageId=* stdin",
     "test-text": "cspell",
     "test": "pnpm run test-dict && pnpm run test-text",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "echo pre-publish"
   },
   "repository": {

--- a/dictionaries/pt_PT/package.json
+++ b/dictionaries/pt_PT/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build",
     "build:conditional": "cspell-tools-cli build --conditional && pnpm gz",
     "gz": "cspell-tools-cli gzip \"dict/*.trie\"",
-    "prepare": "pnpm run gz",
+    "prepare:dictionary": "pnpm run gz",
     "test": "cspell samples"
   },
   "repository": {

--- a/dictionaries/public-licenses/package.json
+++ b/dictionaries/public-licenses/package.json
@@ -21,7 +21,7 @@
     "gen-checksum": "cspell-tools-cli shasum -u checksum.txt --list-file source-files.txt source-dependencies.txt",
     "test": "pnpm run test-dict",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/python/package.json
+++ b/dictionaries/python/package.json
@@ -17,7 +17,7 @@
     "test": "pnpm run test-dictionary && pnpm run test-samples",
     "update-python-lib": "./scripts/fetch-python.sh",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/r/package.json
+++ b/dictionaries/r/package.json
@@ -14,7 +14,7 @@
     "build": "cross-env NODE_OPTIONS=--max_old_space_size=8192 cspell-tools-cli compile --split \"src/r.txt\" -o .",
     "test": "shx head -n 1000 \"src/r.txt\" | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=r\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/redis/package.json
+++ b/dictionaries/redis/package.json
@@ -14,7 +14,7 @@
     "build": "cross-env NODE_OPTIONS=--max_old_space_size=8192 cspell-tools-cli build",
     "test": "shx head -n 1000 \"src/redis-commands.txt\" | cspell -v -c ./cspell.json \"--local=*\" \"--languageId=*\" stdin",
     "prepublishOnly": "echo OK",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/ro_RO/package.json
+++ b/dictionaries/ro_RO/package.json
@@ -18,7 +18,7 @@
     "gen-checksum": "cspell-tools-cli shasum -u checksum.txt --list-file source-files.txt source-dependencies.txt",
     "test": "shx head -n 1000 \"src/Wordlist-Romanian.txt\" | cspell -v -c ./cspell-ext.json \"--local=ro,ro-RO,ro_RO\" \"--languageId=*\" stdin",
     "prepublishOnly": "echo OK",
-    "prepare": "echo OK"
+    "prepare:dictionary": "echo OK"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/ru_RU/package.json
+++ b/dictionaries/ru_RU/package.json
@@ -20,7 +20,7 @@
     "test-russian": "hunspell-reader words -n 1000 \"src/Russian.dic\" | cspell -v -c ./cspell-ext.json --local=ru --languageId=* stdin",
     "test-samples": "cspell -v -c ./cspell-ext.json --local=ru,en \"samples/**\"",
     "test": "pnpm run test-ru_ru && pnpm run test-russian && pnpm run test-samples",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "pnpm run conditional-build && pnpm test"
   },
   "repository": {

--- a/dictionaries/ruby/package.json
+++ b/dictionaries/ruby/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build",
     "test": "shx head -n 100 src/ruby.txt | cspell -v -c ./cspell-ext.json \"--local=en\" \"--languageId=ruby\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/rust/package.json
+++ b/dictionaries/rust/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli compile --keep-raw-case src/rust.txt --no-compress -o ./dict",
     "test": "shx head -n 1000 src/rust.txt | cspell -v -c ./cspell-ext.json --local=* --languageId=rust stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/scala/package.json
+++ b/dictionaries/scala/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build",
     "test": "shx head -n 1000 src/scala.txt | cspell -v -c ./cspell-ext.json --local=* --languageId=scala stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/scientific_terms_US/package.json
+++ b/dictionaries/scientific_terms_US/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build && pnpm gz",
     "test": "shx head -n 1000 \"src/custom_scientific_US.dic.txt\" | cspell -v -c ./cspell-ext.json --local=en --languageId=* stdin",
     "gz": "cspell-tools-cli gzip \"*.trie\"",
-    "prepare": "pnpm gz",
+    "prepare:dictionary": "pnpm gz",
     "prepublishOnly": "echo pre-publish"
   },
   "repository": {

--- a/dictionaries/shell/package.json
+++ b/dictionaries/shell/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build",
     "test": "shx head -n 100 src/legacy-words.txt | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=shellscript\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/sk_SK/package.json
+++ b/dictionaries/sk_SK/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli build && pnpm prepare",
     "build:conditional": "cspell-tools-cli build --conditional && pnpm prepare",
     "test": "hunspell-reader words -n 1000 src/Slovak.dic | cspell -v -c ./cspell-ext.json --local=sk --languageId=* stdin",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "echo pre-publish"
   },
   "repository": {

--- a/dictionaries/sl_SI/package.json
+++ b/dictionaries/sl_SI/package.json
@@ -17,7 +17,7 @@
     "compile:old": "cspell-tools-cli compile --trie3 -x compound --merge sl_si -o . --no-compress --list-file source-files.txt && pnpm run gen-checksum",
     "conditional-build": "pnpm run --silent checksum || pnpm run build",
     "gen-checksum": "cspell-tools-cli shasum -u checksum.txt --list-file source-files.txt source-dependencies.txt",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "echo pre-publish",
     "test-dict": "hunspell-reader words -n 1000 \"./src/hunspell-french-dictionaries-v7.0/fr-classique.dic\" | cspell -v -c ./cspell-ext.json \"--local=fr\" \"--languageId=*\" stdin",
     "test-text": "cspell -v -c ./cspell-ext.json --local=sl \"samples/**\"",

--- a/dictionaries/software-terms/package.json
+++ b/dictionaries/software-terms/package.json
@@ -16,7 +16,7 @@
     "test-software-terms": "cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=*\" --file-list src/source-files-software.txt",
     "test-networking-terms": "cspell -v \"--local=*\" \"--languageId=*\" --file-list src/source-files-networking.txt",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm build"
+    "prepare:dictionary": "pnpm build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/sql/package.json
+++ b/dictionaries/sql/package.json
@@ -16,7 +16,7 @@
     "test-dict": "shx head -n 1000 \"src/sql.txt\" | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=sql\" stdin",
     "test-samples": "cspell \"samples/**\"",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/sv/package.json
+++ b/dictionaries/sv/package.json
@@ -19,7 +19,7 @@
     "test-sv": "hunspell-reader words -n 1000 \"src/ooo-swedish-dict-2-42/dictionaries/sv_SE.dic\" | shx tail -n 200 | cspell -v -c ./cspell-ext.json --local=sv --languageId=* stdin",
     "test-samples": "cspell -v -c ./cspell-ext.json --local=sv,en \"samples/**\"",
     "test": "pnpm run test-sv && pnpm run test-samples",
-    "prepare": "cspell-tools-cli gzip \"*.trie\"",
+    "prepare:dictionary": "cspell-tools-cli gzip \"*.trie\"",
     "prepublishOnly": "pnpm run conditional-build && pnpm test"
   },
   "repository": {

--- a/dictionaries/svelte/package.json
+++ b/dictionaries/svelte/package.json
@@ -16,7 +16,7 @@
     "test-code": "cspell \"**/*.svelte\"",
     "test-src": "shx head -n 1000 \"src/svelte.txt\" | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=svelte\" stdin",
     "prepublishOnly": "echo OK",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/swift/package.json
+++ b/dictionaries/swift/package.json
@@ -14,7 +14,7 @@
     "build": "cross-env NODE_OPTIONS=--max_old_space_size=8192 cspell-tools-cli compile \"src/swift.txt\" -o .",
     "test": "shx head -n 1000 \"src/swift.txt\" | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=swift\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/tr_TR/package.json
+++ b/dictionaries/tr_TR/package.json
@@ -15,7 +15,7 @@
     "build": "cspell-tools-cli build && pnpm gz",
     "build:conditional": "cspell-tools-cli build --conditional && pnpm gz",
     "gz": "cspell-tools-cli gzip \"*.trie\"",
-    "prepare": "pnpm gz",
+    "prepare:dictionary": "pnpm gz",
     "test:dict": "hunspell-reader words -n 1000 \"src/hunspell/Turkish.dic\" | cspell -c ./cspell-ext.json --local=tr --languageId=* stdin",
     "test:samples": "cspell samples",
     "test": "pnpm test:dict && pnpm test:samples",

--- a/dictionaries/typescript/package.json
+++ b/dictionaries/typescript/package.json
@@ -14,7 +14,7 @@
     "build": "cspell-tools-cli compile --keep-raw-case src/typescript.txt --no-compress -o ./dict",
     "test": "shx head -n 100 src/typescript.txt | cspell -v -c ./cspell-ext.json \"--local=*\" \"--languageId=typescript\" stdin",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/vi_VN/package.json
+++ b/dictionaries/vi_VN/package.json
@@ -15,7 +15,7 @@
     "build:conditional": "cspell-tools-cli build --conditional && pnpm gz",
     "test": "cspell samples",
     "gz": "cspell-tools-cli gzip *.trie",
-    "prepare": "pnpm run gz",
+    "prepare:dictionary": "pnpm run gz",
     "prepublishOnly": "echo pre-publish"
   },
   "repository": {

--- a/dictionaries/vue/package.json
+++ b/dictionaries/vue/package.json
@@ -14,7 +14,7 @@
     "build": "echo skip",
     "test": "echo skip",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/dictionaries/win32/package.json
+++ b/dictionaries/win32/package.json
@@ -16,7 +16,7 @@
     "test-src": "shx head -n 10000 \"src/win32.txt\" | cspell -v -c ./cspell.json \"--local=*\" stdin",
     "test-samples": "cspell samples/**",
     "prepublishOnly": "echo pre-publish",
-    "prepare": "pnpm run build"
+    "prepare:dictionary": "pnpm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "clean": "shx rm -rf \"packages/*/*.txt.gz\" \"dictionaries/*/*.txt.gz\"",
     "readme:generate-doc-dictionaries": "./scripts/dictionaries.sh > dictionaries.md",
     "readme:inject": "inject-markdown \"*.md\" \"dictionaries/*/README.md\" && prettier -w \"*.md\" \"dictionaries/*/README.md\"",
-    "prepare": "echo OK",
+    "prepare": "pnpm -r run --stream --workspace-concurrency 3 prepare:dictionary",
     "pub-recover": "lerna publish from-package --no-push --no-private --concurrency 1",
     "update-packages": "pnpm up",
     "preinstall": "npx only-allow pnpm"


### PR DESCRIPTION
## Description

After pnpm 8.6.0, `pnpm i` had become unreliable, often failing randomly with an error like `sh 1: <cli-tool> Permission denied`.

<img width="669" alt="image" src="https://github.com/streetsidesoftware/cspell-dicts/assets/3740137/6aeb0d3a-6ccd-4777-85be-d59cb1560250">

I believe this is related to https://github.com/pnpm/pnpm/issues/6968

The work around is to remove the `prepare` life-cycle script from each of the packages and instead make a top level recursive call with limited concurrency.


## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
