### PR TITLE
fix: Add "hhatto" to Python dictionary

### DIFF
--- a/dictionaries/python/src/common_packages.txt
+++ b/dictionaries/python/src/common_packages.txt
@@ -39,6 +39,7 @@ gces-trab
 Gensim
 helpdesk
 helpdesk-achange
+hhatto
 horovod
 imap
 iptv


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: software-terms

## Description

"hhatto" owns the popular autopep8 repository.

## References

https://github.com/hhatto/autopep8

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.