### PR TITLE
fix: add some ubuntu distributions to network-os.txt

### DIFF
--- a/dictionaries/software-terms/src/network-os.txt
+++ b/dictionaries/software-terms/src/network-os.txt
@@ -13,3 +13,7 @@ routeros
 sros
 tmos
 vyos
+xubuntu 
+lubuntu 
+kylin
+Edubuntu


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: network-os.txt

## Description

add some ubuntu distributions to network-os.txt

## References


| xubuntu  | https://xubuntu.org/                   |
|----------|----------------------------------------|
| lubuntu  | https://lubuntu.me/                    |
| kylin    | https://www.ubuntukylin.com            |
| Edubuntu | https://www.edubuntu.org/              |

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
