### PR TITLE
fix: add some linux display manager to software-tools.txt

### DIFF
--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -234,3 +234,10 @@ ZeroMQ
 zsh
 Zuul
 Zypper
+xfce
+lightdm
+sddm
+lxdm
+xfwm
+lxqt
+xinit


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: software-tools.txt

## Description

add some linux display manager to software-tools.txt

## References

| term     | reference.                             |
|----------|----------------------------------------|
| xfce     | https://xfce.org/                      |
| lightdm  | https://github.com/canonical/lightdm   |
| sddm     | https://github.com/sddm/sddm           |
| lxdm     | https://wiki.archlinux.org/title/LXDM  |
| xfwm     | https://wiki.archlinux.org/title/Xfwm  |
| lxqt     | https://lxqt-project.org/              |
| xinit    | https://wiki.archlinux.org/title/Xinit |

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
