### PR TITLE
fix: add "behaviour" and "discolour" to GB English dictionary

### DIFF
--- a/dictionaries/en_GB/src/additional_words.txt
+++ b/dictionaries/en_GB/src/additional_words.txt
@@ -5,11 +5,13 @@ Alpha Centauri
 amphitheatre
 Aruban
 Arubans
+behaviour
 bicep
 Christoph
 computerised
 conformant
 COVID
+discolour
 dropshipper
 dropshippers
 dropshipping


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _dictionaries/en_US/src/additional_words.txt_

## Description

Add "behaviour" and "discolour" to GB English dictionary.

In British English, words ending in "-our" have the letter "u" removed in American English if it is not pronounced. For example: behaviour/behavior, discolour/discolor, labour/labor, etc.

## References

- [Behavior vs. behaviour](https://grammarist.com/spelling/behavior-behaviour/)
- https://www.oxfordlearnersdictionaries.com/definition/english/behaviour
- https://www.oxfordlearnersdictionaries.com/definition/english/discolour?q=discolour

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
