### PR TITLE
fix: Add some language terms for the "php" dict

### DIFF
--- a/dictionaries/php/src/php.txt
+++ b/dictionaries/php/src/php.txt
@@ -8,7 +8,6 @@ Attr
 break
 Caching
 callable
-Capistrano
 case
 catch
 Cdata
@@ -19,7 +18,6 @@ clone
 Comment
 COMPILE
 compiler
-composer
 Configuration
 const
 constants
@@ -65,6 +63,7 @@ final
 finally
 for
 foreach
+FQCN
 Fragment
 function
 FUNCTION
@@ -116,11 +115,8 @@ NULL
 object
 once
 or
-packagist
 Parent
 Path
-PEAR
-pecl
 php
 phpapi
 phpdoc
@@ -149,8 +145,8 @@ static
 std
 STRICT
 String
+Stringable
 switch
-symfony
 Text
 throw
 trait
@@ -332,3 +328,17 @@ CURLOPT_TCP_KEEPIDLE
 CURLOPT_TCP_KEEPINTVL
 CURLOPT_XOAUTH2_BEARER
 CURLSSLOPT_ALLOW_BEAST
+
+# 3rd party vendors and packages
+Capistrano
+composer
+packagist
+pcov
+PEAR
+pecl
+phpmd
+phpstan
+phpunit
+psalm
+PSR
+symfony


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: php

## Description

Add `3rd party vendors and packages` section, moved some vendor and package names there, added some terms.

## References

Added terms:
- [FQCN](https://www.php.net/manual/en/language.namespaces.rules.php) (Fully Qualified Class Name);
- [pcov](https://pecl.php.net/package/pcov)
- [phpmd](https://phpmd.org/);
- [phpstan](https://phpstan.org/);
- [phpunit](https://phpunit.de/);
- [psalm](https://psalm.dev/);
- [PSR](https://www.php-fig.org/psr/);
- [Stringable](https://www.php.net/manual/en/class.stringable.php).

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
