### PR TITLE
fix: Add "Gitleaks" to software tools dict

### DIFF
--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -67,6 +67,7 @@ git
 GitHub
 Gitkraken
 GitLab
+Gitleaks
 Gitpod
 GKE
 GMail


### PR DESCRIPTION
[Gitleaks](https://github.com/gitleaks/gitleaks) is a tool for detecting and preventing hardcoded secrets.

<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: software-tools

## Description

Add "Gitleaks"

## References

[Gitleaks website](https://gitleaks.io/)

## Checklist

- [ ] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [ ] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
