### PR TITLE
fix: Add "regexes" to software-terms dictionary

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -1159,6 +1159,7 @@ refetch
 refetching
 refname
 regex
+regexes
 regexp
 rehydrate
 rehydrated


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: software-terms

## Description

Add "regexes."

## References

- https://en.wikipedia.org/wiki/Regular_expression

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.