### PR TITLE
fix: Add OpenAPI to software terms

### DIFF
--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -153,6 +153,7 @@ Octicons
 octokit
 Ohai
 OmniOS
+OpenAPI
 OpenBSD
 openindiana
 OpenIndiana


### PR DESCRIPTION
# Add To Dictionary

Dictionary: Software Terms

## Description

Add OpenAPI

## References

[https://en.wikipedia.org/wiki/OpenAPI_Specification](https://en.wikipedia.org/wiki/OpenAPI_Specification)