### PR TITLE
Fix: Add signin and signout to software terms

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -1290,6 +1290,8 @@ SIGQUIT
 sigs
 SIGTERM
 sin
+signin
+signout
 sinon
 sizeof
 slapd


### PR DESCRIPTION
# Add To Dictionary

Dictionary: Software Terms

## Description

Add **_signin_** and **_signout_**

Often these are used with things like routes: `/signin` and `/signout`