### PR TITLE
fix: add sqlserver to software terms

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -1313,6 +1313,7 @@ Sparc
 SPDX
 sql
 SQL
+sqlserver
 sqrt
 squigglies
 src


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: software terms

## Description

add `sqlserver` to software terms