### PR TITLE
fix: add MSSQL to software tools

### DIFF
--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -140,6 +140,7 @@ mkdir
 mongod
 MongoDB
 monit
+MSSQL
 MySQL
 Nagios
 nano


### PR DESCRIPTION
Add `MSSQL` to software tools