### PR TITLE
fix: add viewports (plural) to css dictionary

### DIFF
--- a/dictionaries/css/src/css.txt
+++ b/dictionaries/css/src/css.txt
@@ -1103,6 +1103,7 @@ vh
 video
 view
 viewport
+viewports
 violet
 visibility
 visible


### PR DESCRIPTION
add viewports plural