### PR TITLE
fix: add neovim to shell words

### DIFF
--- a/dictionaries/shell/src/command-words.txt
+++ b/dictionaries/shell/src/command-words.txt
@@ -2,6 +2,7 @@ dbus
 dpkg
 emacs
 mkdir
+neovim
 newgidmap
 newuidmap
 notify


### PR DESCRIPTION
[https://neovim.io/](https://neovim.io/)