### PR TITLE
fix: Remove `indispensible`

### DIFF
--- a/dictionaries/en_US/src/en_US.txt
+++ b/dictionaries/en_US/src/en_US.txt
@@ -9651,7 +9651,6 @@ indiscoverable
 indiscriminantly
 indiscriminating
 indispensabilities
-indispensible
 inditer
 inditers
 indiums


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: en-US

## Description

Not sure how it got there.

fixes #2535


## References

- [indispensible or indispensable](https://www.google.com/search?q=indispensible+or+indispensable)

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
