### PR TITLE
feat: Enable dictionary `web-services` by default

### DIFF
--- a/dictionaries/software-terms/cspell-ext.json
+++ b/dictionaries/software-terms/cspell-ext.json
@@ -33,8 +33,8 @@
     // Enable `softwareTerms` by default if this extension is imported.
     "dictionaries": [
         "softwareTerms",
-        "computing-acronyms"
+        "computing-acronyms",
         // "networking-terms" - is not included by default because it is very specific.
-        // "web-services" - is not included by default
+        "web-services"
     ]
 }

--- a/dictionaries/software-terms/src/software-services.txt
+++ b/dictionaries/software-terms/src/software-services.txt
@@ -1,9 +1,11 @@
+# Add Web Services to this list
 Appointedd
-Calendly
-Caniuse
+calendly
+caniuse
 cdnjs
 imessage
 jsdelivr
 musixmatch
-Todoist
+todoist
 unpkg
+netlify


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: `web-services`

## Description

Turn it on by default since some services are becoming popular and should not be added to the companies list.

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
