### PR TITLE
fix: add font feature words to css

### DIFF
--- a/dictionaries/css/src/css.txt
+++ b/dictionaries/css/src/css.txt
@@ -144,8 +144,11 @@ canvas
 capitalize
 caps
 caption
+c2sc
+calt
 captures
 caret
+case
 cell
 cells
 center
@@ -282,6 +285,7 @@ display
 distribute
 div
 dl
+dlig
 dodge
 dodgerblue
 dominant
@@ -353,6 +357,7 @@ fill
 filled
 filter
 filters
+fina
 fine
 firebrick
 first
@@ -376,6 +381,7 @@ format
 forward
 forwards
 fr
+frac
 fragment
 fragments
 from
@@ -426,6 +432,8 @@ helvetica
 hgroup
 hidden
 hiragana
+hist
+hlig
 honeydew
 horizontal
 hostfunction
@@ -464,6 +472,7 @@ indigo
 infinite
 informal
 inherit
+init
 initial
 ink
 inline
@@ -481,6 +490,7 @@ into
 invalid
 invert
 iroha
+isol
 isolate
 isolation
 italic
@@ -493,6 +503,7 @@ justify
 katakana
 kbd
 keep
+kern
 kerning
 key
 keyEquivalent
@@ -527,6 +538,7 @@ length
 letter
 level
 li
+liga
 ligatures
 light
 lightblue
@@ -558,7 +570,9 @@ link
 list
 listbox
 lnum
+lnum
 local
+locl
 logic
 logical
 loop
@@ -595,6 +609,7 @@ max
 maximize
 maximized
 maximum
+medi
 media
 medium
 mediumaquamarine
@@ -635,6 +650,7 @@ mistyrose
 miterlimit
 mix
 mixed
+mkmk
 mm
 moccasin
 mode
@@ -692,6 +708,7 @@ olive
 olivedrab
 on
 only
+onum
 opacity
 open
 opentype
@@ -838,6 +855,7 @@ richness
 ridge
 right
 rl
+rlig
 role
 roman
 root
@@ -930,6 +948,7 @@ slategrey
 slice
 small
 smaller
+smcp
 smooth
 snap
 snow
@@ -979,6 +998,7 @@ styleset
 sub
 subgrid
 suboptimum
+subs
 subtract
 suffix
 summary
@@ -986,11 +1006,13 @@ sup
 super
 support
 suppress
+sups
 susy
 svg
 svmax
 svmin
 sw
+swsh
 symbol
 symbolic
 symbols
@@ -1033,6 +1055,7 @@ times
 timing
 title
 titlebar
+tnum
 tnum
 to
 tomato


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings

- c2sc (small capitals from capitals)
- calt (contextual alternates)
- case (case-sensitive forms)
- dlig (discretionary ligatures)
- fina (final forms)
- frac (fractions)
- hist (historical forms)
- hlig (historical ligatures)
- init (initial forms)
- isol (isolated forms)
- kern (kerning)
- liga (standard ligatures)
- lnum (lining figures)
- locl (localized forms)
- medi (medial forms)
- mkmk (mark-to-mark positioning)
- onum (old style figures)
- rlig (required ligatures)
- smcp (small caps)
- subs (subscript)
- sups (superscript)
- swsh (swashes)
- tnum (tabular figures)
- zero (slashed zero)