### PR TITLE
fix: Add "proselint" and "proselintrc" to software-terms dictionary

### DIFF
--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -189,6 +189,8 @@ Portainer
 PostgresSQL
 prettier
 prettierd
+proselint
+proselintrc
 pspings
 PyCharm
 Redis


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: software-terms

## Description

Add "proselint" and "proselintrc." Proselint is a linter that uses a `.proselintrc` config file.

## References

- [Proselint](https://github.com/amperser/proselint)

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
