### PR TITLE
fix: add jsonapi to software terms

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -723,6 +723,7 @@ jsconfig
 jshint
 jslint
 json
+jsonapi
 jsonb
 jsonc
 jsonp


### PR DESCRIPTION
https://jsonapi.org