### PR TITLE
fix: add mindepth and maxdepth to software terms

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -837,6 +837,7 @@ manpage
 map
 mapfn
 markdown
+maxdepth
 maxkb
 maxptime
 mdadm
@@ -878,6 +879,7 @@ microservices
 middleware
 middlewares
 mimetype
+mindepth
 minepart
 mingw
 minification


### PR DESCRIPTION
used with tools like `find`

https://man7.org/linux/man-pages/man1/find.1.html