### PR TITLE
fix: Make license documentation consistent

### DIFF
--- a/dictionaries/cs_CZ/README.md
+++ b/dictionaries/cs_CZ/README.md
@@ -51,4 +51,4 @@ MIT
 
 > Some packages may have other licenses included.
 
-See also: [Czech.txt](Czech.txt)
+See also: [Czech.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/cs_CZ/Czech.txt)

--- a/dictionaries/de_DE/README.md
+++ b/dictionaries/de_DE/README.md
@@ -50,4 +50,4 @@ The Hunspell source for this dictionary can be found:
 GPL-3.0-or-later
 
 > Some packages may have other licenses included.
-> See [src/hunspell/license](./src/hunspell/license) and [src/German_de_DE.txt](./src/German_de_DE.txt)
+> See [src/hunspell/license](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/de_DE/src/hunspell/license) and [src/German_de_DE.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/de_DE/src/German_de_DE.txt)

--- a/dictionaries/de_DE/README.md
+++ b/dictionaries/de_DE/README.md
@@ -47,4 +47,7 @@ The Hunspell source for this dictionary can be found:
 
 ## License
 
-MIT
+GPL-3.0-or-later
+
+> Some packages may have other licenses included.
+> See [src/hunspell/license](./src/hunspell/license) and [src/German_de_DE.txt](./src/German_de_DE.txt)

--- a/dictionaries/en_AU/README.md
+++ b/dictionaries/en_AU/README.md
@@ -48,7 +48,7 @@ npm run build
 
 ## Adding Words
 
-Please add any words to [src/additional_words.txt](./src/additional_words.txt) by making a pull request.
+Please add any words to [src/additional_words.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_AU/src/additional_words.txt) by making a pull request.
 
 ## License
 

--- a/dictionaries/en_CA/README.md
+++ b/dictionaries/en_CA/README.md
@@ -48,7 +48,7 @@ npm run build
 
 ## Adding Words
 
-Please add any words to [src/additional_words.txt](./src/additional_words.txt) by making a pull request.
+Please add any words to [src/additional_words.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_CA/src/additional_words.txt) by making a pull request.
 
 ## License
 

--- a/dictionaries/en_GB-MIT/README.md
+++ b/dictionaries/en_GB-MIT/README.md
@@ -43,7 +43,7 @@ npm run build
 
 ## Adding Words
 
-Please add any words to [src/additional_words.txt](./src/additional_words.txt) by making a pull request.
+Please add any words to [src/additional_words.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_GB-MIT/src/additional_words.txt) by making a pull request.
 
 ## License
 

--- a/dictionaries/en_GB/README.md
+++ b/dictionaries/en_GB/README.md
@@ -48,7 +48,7 @@ npm run build
 
 ## Adding Words
 
-Please add any words to [src/additional_words.txt](./src/additional_words.txt) by making a pull request.
+Please add any words to [src/additional_words.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_GB/src/additional_words.txt) by making a pull request.
 
 ## License
 

--- a/dictionaries/en_US/README.md
+++ b/dictionaries/en_US/README.md
@@ -52,7 +52,7 @@ npm run build
 
 ## Adding Words
 
-Please add any words to [src/additional_words.txt](./src/additional_words.txt) by making a pull request.
+Please add any words to [src/additional_words.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_US/src/additional_words.txt) by making a pull request.
 
 ## Resources
 

--- a/dictionaries/es_ES/README.md
+++ b/dictionaries/es_ES/README.md
@@ -41,7 +41,7 @@ npm run build
 
 ## Adding Words
 
-Please add any words to [src/additional_words.txt](./src/additional_words.txt) by making a pull request.
+Please add any words to [src/additional_words.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/es_ES/src/additional_words.txt) by making a pull request.
 
 ## Resources
 
@@ -54,4 +54,4 @@ The Hunspell source for this dictionary can be found:
 GPL-3.0-or-later
 
 > Some packages may have other licenses included.
-> See [src/hunspell/license](./src/hunspell/license)
+> See [src/hunspell/license](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/src/hunspell/license)

--- a/dictionaries/es_ES/README.md
+++ b/dictionaries/es_ES/README.md
@@ -51,6 +51,7 @@ The Hunspell source for this dictionary can be found:
 
 ## License
 
-MIT
+GPL-3.0-or-later
 
 > Some packages may have other licenses included.
+> See [src/hunspell/license](./src/hunspell/license)

--- a/dictionaries/nl_NL/README.md
+++ b/dictionaries/nl_NL/README.md
@@ -44,7 +44,7 @@ npm run build
 MIT
 
 > Some packages may have other licenses included.
-> See: Dutch.txt
+> See: [hunspell Dutch license](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/nl_NL/src/hunspell/license)
 
 ## Resources
 

--- a/dictionaries/pl_PL/README.md
+++ b/dictionaries/pl_PL/README.md
@@ -51,4 +51,4 @@ The Hunspell source for this dictionary can be found in several repositories:
 LGPL-3.0+
 
 > Some packages may have other licenses included.
-> See [src/hunspell/license](./src/hunspell/license)
+> See [src/hunspell/license](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/src/hunspell/license)

--- a/dictionaries/pl_PL/README.md
+++ b/dictionaries/pl_PL/README.md
@@ -48,6 +48,7 @@ The Hunspell source for this dictionary can be found in several repositories:
 
 ## License
 
-MIT
+LGPL-3.0+
 
 > Some packages may have other licenses included.
+> See [src/hunspell/license](./src/hunspell/license)

--- a/dictionaries/pt_BR/README.md
+++ b/dictionaries/pt_BR/README.md
@@ -41,6 +41,6 @@ npm run build
 
 ## License
 
-[GPL-3.0-or-later](./LICENSE)
+[GPL-3.0-or-later](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/pt_BR/LICENSE)
 
 > Some packages may have other licenses included.

--- a/dictionaries/pt_PT/README.md
+++ b/dictionaries/pt_PT/README.md
@@ -48,6 +48,6 @@ The Hunspell source for this dictionary can be found:
 ## License
 
 MIT
-See: Portuguese-European.txt
+See: [Portuguese-European.dic license](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/pt_PT/src/hunspell/LICENSE)
 
 > Some packages may have other licenses included.

--- a/dictionaries/ru_RU/README.md
+++ b/dictionaries/ru_RU/README.md
@@ -49,7 +49,7 @@ GPL-3.0-or-later
 
 ## Adding Missing Words
 
-Please add words to [additional_words.txt](./src/additional_words.txt)
+Please add words to [additional_words.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/src/additional_words.txt)
 
 ## Building
 

--- a/dictionaries/sk_SK/README.md
+++ b/dictionaries/sk_SK/README.md
@@ -54,7 +54,7 @@ MPL v2
 See also:
 
 - [sk-spell/hunspell-sk](https://github.com/sk-spell/hunspell-sk#readme)
-- [Slovak.txt](./Slovak.txt)
+- [Slovak.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/src/Slovak.txt)
 
 ## Contributors
 

--- a/dictionaries/sl_SI/README.md
+++ b/dictionaries/sl_SI/README.md
@@ -53,4 +53,4 @@ GNU/LGPL and GNU/GPL
 
 > Some packages may have other licenses included.
 
-See also: [README_sl_SI.txt](./src/README_sl_SI.txt)
+See also: [README_sl_SI.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/sl_SIsrc/README_sl_SI.txt)


### PR DESCRIPTION
<!---
name: Update license documentation
about: Makes license documentation consistent for several dictionaries that are released under licenses other than MIT, but which nonetheless said MIT in the README
title: 'feat: Make license documentation consistent'
labels: dictionary
--->

# Make license documentation consistent

Dictionaries (update license info): de_DE, es_ES, pl_PL

## Description

In each of these dictionaries, there are the following: 
1) a LICENSE file
2) a license listed in package.json
3) a license referenced in the README.

In these three dictionaries, (1) and (2) match, but (3) did not, and instead said `MIT`.  This PR does not change the license the dictionaries are released under, but does fix the documentation in the READMEs so that (3) matches (1) and (2).

## References

n/a

# Fix links

Additionally, this changes some relative links to hard-coded URLs, so that they will work in their NPM packages:

Dictionaries (update links): cs_CZ, de_DE, en_AU, en_CA, en_GB, en_GB-MIT, en_US, es_ES, nl_NL, pl_PL, pt_BR, pt_PT, ru_RU, sk_SK, sl_SI

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
