### PR TITLE
fix: Add "archivable" to English dictionaries

### DIFF
--- a/dictionaries/en_US/src/hunspell/en_US-large.dic
+++ b/dictionaries/en_US/src/hunspell/en_US-large.dic
@@ -19964,6 +19964,7 @@ architectonics/M
 architectural/Y
 architecture/MS
 architrave/SM
+archivable
 archival
 archive/DSMG
 archivist/MS

--- a/dictionaries/en_US/src/hunspell/en_US-large.dic
+++ b/dictionaries/en_US/src/hunspell/en_US-large.dic
@@ -19964,7 +19964,6 @@ architectonics/M
 architectural/Y
 architecture/MS
 architrave/SM
-archivable
 archival
 archive/DSMG
 archivist/MS

--- a/dictionaries/en_shared/src/shared-additional-words.txt
+++ b/dictionaries/en_shared/src/shared-additional-words.txt
@@ -4,6 +4,8 @@ aesthetical
 Alpha Centauri
 amphitheatre
 anthropomorphization
+archivable
+archivables
 Aruban
 Arubans
 bicep


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: _en_US_

## Description

_Add "archivable" to en_US_

## References

- [_Merriam-Webster_](https://www.merriam-webster.com/dictionary/archivable)

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
