### PR TITLE
fix: Add `themeable` to software terms

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -1950,3 +1950,5 @@ zip
 zlib
 ZPool
 ZPools
+themeable
+themeables


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: Software Terms

## References

- [themeable - Wiktionary, the free dictionary](https://en.wiktionary.org/wiki/themeable)
- [ThemeableAttribute.Themeable Property (System.Web.UI) | Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/api/system.web.ui.themeableattribute.themeable?view=netframework-4.8.1)

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
