### PR TITLE
fix: remove typo from fsharp dictionary

### DIFF
--- a/dictionaries/fsharp/dict/fsharp.txt
+++ b/dictionaries/fsharp/dict/fsharp.txt
@@ -190,7 +190,6 @@ null
 nullary
 nullness
 object
-occurence
 of
 open
 or

--- a/dictionaries/fsharp/src/from-fsharp-src.txt
+++ b/dictionaries/fsharp/src/from-fsharp-src.txt
@@ -119,7 +119,6 @@ noframework
 notlazy
 nullary
 nullness
-occurence
 outfile
 parens
 pdef


### PR DESCRIPTION
name: Remove typo from fsharp
about: PR for typo from fsharp dictionary
title: 'fix: '
labels: dictionary

# Add/Fix Dictionary

Dictionary: fsharp

## Description

Remove typo 

## References

https://github.com/streetsidesoftware/cspell-dicts/blob/2115190bae015aedb8832bc8384088ed36cfce9a/dictionaries/en-common-misspellings/dict-en.yaml#L2561

## Checklist

- [x] By submitting this issue, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
