### PR TITLE
fix: Add several filetypes

### DIFF
--- a/dictionaries/filetypes/filetypes.txt
+++ b/dictionaries/filetypes/filetypes.txt
@@ -55,6 +55,7 @@ config
 cpp
 cpt
 cpy
+crx
 cshtml
 csl
 cson
@@ -77,6 +78,7 @@ docm
 docx
 dot
 dotx
+drawio
 dsql
 dtd
 dtml
@@ -201,6 +203,7 @@ owl
 p6
 patch
 pdf
+pem
 perl
 perl6
 php
@@ -242,6 +245,7 @@ pub
 pubxml
 pubxmluser
 pug
+puml
 py
 python
 pyw


### PR DESCRIPTION
<!---
name: Add several filetypes to filetypes Dictionary
about: PR for adding filetypes to filetypes dictionary
title: 'fix: Add several filetypes'
labels: dictionary
--->

# Add to filetypes Dictionary

Dictionary: _filetypes_

## Description

Adds

- pem
- crx
- puml
- drawio

## References

- https://stackoverflow.com/questions/50615890/what-is-the-chrome-extension-pem-file-for
- https://plantuml.com/sources
- https://www.drawio.com/doc/faq/save-file-formats#:~:text=.drawio%20(XML%20file)%3A%20this,with%20our%20file%20extension%20name.

## Checklist

- [x] By submitting this pull-request, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
