### PR TITLE
fix: Add "PYTHONHOME" to python dict

### DIFF
--- a/dictionaries/python/src/python/python.txt
+++ b/dictionaries/python/src/python/python.txt
@@ -639,6 +639,7 @@ pyproject
 pypy
 pyright
 pytest
+PYTHONHOME
 pyyaml
 queue
 quit


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: python

## Description

Add "PYTHONHOME" to the python dictionary.

## References

[Python documentation](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONHOME) of the PYTHONHOME environment variable
