### PR TITLE
fix: add isempty to vim dict

### DIFF
--- a/dictionaries/vim/src/vim.txt
+++ b/dictionaries/vim/src/vim.txt
@@ -159,6 +159,7 @@ inoreabbrev
 inoremap
 inoremenu
 isearch
+isempty
 isplit
 iunabbrev
 iunmap


### PR DESCRIPTION
add `isempty` to vim dictionary