### PR TITLE
fix: Add OPTARG to bash-words.txt

### DIFF
--- a/dictionaries/bash/src/bash-words.txt
+++ b/dictionaries/bash/src/bash-words.txt
@@ -112,6 +112,7 @@ notify
 nounset
 OLDPWD
 onecmd
+OPTARG
 OPTERR
 OPTIND
 OSTYPE


### PR DESCRIPTION
Per https://man7.org/linux/man-pages/man1/getopts.1p.html

<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: bash

## Description

- Add OPTARG to bash-words.txt

## References

- https://man7.org/linux/man-pages/man1/getopts.1p.html

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
