### PR TITLE
fix: Add some npmcli and npm-package-json-lint terms

### DIFF
--- a/dictionaries/npm/src/npm.txt
+++ b/dictionaries/npm/src/npm.txt
@@ -507,8 +507,13 @@ normalize.css
 npm
 npm-check
 npm-check-updates
+npm-package-json-lint
 npm-run-all
 npm-windows-upgrade
+npmcli
+npmpackagejsonlint
+npmpackagejsonlintignore
+npmpackagejsonlintrc
 nsp
 numeral
 nunjucks


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: npm

## Description

Add "npmcli," "npm-package-json-lint," "npmpackagejsonlint," "npmpackagejsonlintignore," and "npmpacakgejsonlintrc" to npm dictionary.

## References

- https://www.npmjs.com/package/@npmcli/fs
- https://npmpackagejsonlint.org/docs/configuration
- https://npmpackagejsonlint.org/docs/ignore

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
