### PR TITLE
fix: Add "datasources" to software-terms dict

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -344,6 +344,7 @@ databases
 dataloader
 dataset
 datasets
+datasources
 DAWG
 dcopy
 DDMMYY


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: software-terms

## Description

Add the term "datasources," which is used in Renovate's config files, for example.

## References

- https://docs.renovatebot.com/modules/datasource/

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
