### PR TITLE
fix: Add some Gitleaks, Slack API, and Trivy terms

### DIFF
--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -73,6 +73,7 @@ GitHub
 Gitkraken
 GitLab
 Gitleaks
+gitleaksignore
 Gitpod
 GKE
 GMail
@@ -207,6 +208,7 @@ sddm
 Secretlint
 secretlintignore
 Sharpier
+SlackAPI
 SmartOS
 snmpd
 snmptrapd
@@ -228,6 +230,8 @@ textmate
 tmux
 Trello
 trex
+Trivy
+trivyignore
 tzinfo
 tzutil
 ubound


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: software-terms

## Description

Add "gitleaksignore," "SlackAPI," "Trivy," and "trivyignore."

## References

- [gitleaksignore](https://github.com/gitleaks/gitleaks/blob/8de8938ad425d11edb0986c38890116525a36035/README.md#gitleaksignore)
- [SlackAPI](https://github.com/slackapi/)
- [Trivy](https://aquasecurity.github.io/trivy/)
- [trivyignore](https://aquasecurity.github.io/trivy/v0.48/docs/configuration/filtering/#trivyignore)

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
