### PR TITLE
feat!: [git] Add a "git" dictionary to hold git related terms.

### DIFF
--- a/dictionaries/git/cspell-ext.json
+++ b/dictionaries/git/cspell-ext.json
@@ -3,8 +3,81 @@
     "version": "0.2",
     "name": "git",
     "description": "CSpell configuration for GIT",
-    "dictionaryDefinitions": [],
+    "dictionaryDefinitions": [
+        {
+            "name": "git",
+            "description": "Git Terms",
+            "words": [
+                "add",
+                "am",
+                "applypatch",
+                "autocrlf",
+                "bare",
+                "bisect",
+                "blame",
+                "branch",
+                "bundle",
+                "checkout",
+                "cherry-pick",
+                "citool",
+                "clean",
+                "clone",
+                "commit",
+                "cygwin",
+                "describe",
+                "diff",
+                "EDITMSG",
+                "fetch",
+                "filemode",
+                "format-patch",
+                "fsmonitor",
+                "gc",
+                "GIT_AUTHOR_IDENT",
+                "gitk",
+                "grep",
+                "gui",
+                "helper",
+                "hook",
+                "ignorecase",
+                "init",
+                "instaweb",
+                "log",
+                "logallrefupdates",
+                "merge",
+                "msg",
+                "mv",
+                "notes",
+                "precommit",
+                "precomposeunicode",
+                "prepare",
+                "pull",
+                "push",
+                "rebase",
+                "repositoryformatversion",
+                "reset",
+                "rev",
+                "revert",
+                "rm",
+                "shortlog",
+                "show",
+                "stash",
+                "status",
+                "submodule",
+                "tag",
+                "watchman",
+                "whatchanged"
+            ]
+        }
+    ],
     "dictionaries": [],
+    "ignorePaths": [
+        "**/.git/info/refs",
+        "**/.git/{logs,objects,packed-refs,refs}",
+        "**/.git/HEAD",
+        "**/.git/index",
+        "**/.git/FETCH_HEAD",
+        "**/.git/ORIGIN_HEAD"
+    ],
     "languageSettings": [
         {
             "languageId": "commit-msg",
@@ -20,9 +93,13 @@
     ],
     "overrides": [
         {
-            "filename": "${cwd}/.git/COMMIT_EDITMSG",
+            "filename": "**/.git/COMMIT_EDITMSG",
             "languageId": "commit-msg",
             "minWordLength": 3
+        },
+        {
+            "filename": "**/.git/**",
+            "dictionaries": ["git"]
         }
     ]
 }

--- a/dictionaries/git/cspell.json
+++ b/dictionaries/git/cspell.json
@@ -2,13 +2,9 @@
     "files": [
         "**/*.{md,txt}"
     ],
-    "dictionaries": [],
+    "dictionaries": ["git"],
     "import": [
         "./cspell-ext.json"
     ],
-    "ignoreWords": [],
-    "words": [
-        "autocrlf",
-        "EDITMSG"
-    ]
+    "ignoreWords": []
 }

--- a/dictionaries/git/cspell.json
+++ b/dictionaries/git/cspell.json
@@ -8,6 +8,7 @@
     ],
     "ignoreWords": [],
     "words": [
+        "autocrlf",
         "EDITMSG"
     ]
 }


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: git

## Description

Add "autocrlf" term

## References

- [autocrlf](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf).

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
