### PR TITLE
fix: add `rustfmt` to rust dictionary

### DIFF
--- a/dictionaries/rust/src/rust.txt
+++ b/dictionaries/rust/src/rust.txt
@@ -82,6 +82,7 @@ ref
 RefCell
 Rem
 return
+rustfmt
 self
 Self
 serde


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: [Rust](https://github.com/streetsidesoftware/cspell-dicts/tree/main/dictionaries/rust)
## Description

This PR adds "rustfmt" to the Rust dictionary as it's a common tool used in rust projects.

## References

- https://github.com/rust-lang/rustfmt

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
