### PR TITLE
fix: add "msrv" to rust dictionary

### DIFF
--- a/dictionaries/rust/src/rust.txt
+++ b/dictionaries/rust/src/rust.txt
@@ -61,6 +61,7 @@ millis
 mod
 move
 mpsc
+msrv
 Mul
 mut
 mutex


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _dictionary_

## Description

This PR adds the acronym "msrv" (Minimum supported rust version) to the Rust dictionary.

## References

- Usage of MSRV is shown here: https://rust-lang.github.io/rfcs/2495-min-rust-version.html

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
