### PR TITLE
fix: correct "BitAdd" to "BitAnd" in rust dictionary

### DIFF
--- a/dictionaries/rust/src/rust.txt
+++ b/dictionaries/rust/src/rust.txt
@@ -7,7 +7,7 @@ as
 assert
 assert_eq
 become
-BitAdd
+BitAnd
 BitOr
 BitXor
 bool


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: Rust

## Description

Apologies for the PR spam, I'm opening these as I run into issues as they should be quick to review.

This PR fixes a spelling mistake where what I expect was "BitAnd" got changed into "BitAdd". The "BitAdd" operator doesn't really make sense to me plus I can't find any references to one on google so I've just replaced it.

## References

- https://doc.rust-lang.org/std/ops/trait.BitAnd.html

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
