### PR TITLE
fix: add Despawn to gaming-terms dictionary

### DIFF
--- a/dictionaries/gaming-terms/src/gaming-terms.txt
+++ b/dictionaries/gaming-terms/src/gaming-terms.txt
@@ -6,6 +6,7 @@ Cutscene
 DBNO
 Deathmatch
 Debuff
+Despawn
 Diggable
 Faceroll
 Gamebattles


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: gaming-terms

## Description

Add the term "despawn". It is used in gaming and game development.

## References
[Wikipedia](https://en.wikipedia.org/wiki/Spawning_(video_games))

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
