### PR TITLE
fix: Fix spelling of subsytem in CPP word list (to subsystem)

### DIFF
--- a/dictionaries/cpp/src/cpp.txt
+++ b/dictionaries/cpp/src/cpp.txt
@@ -85320,7 +85320,7 @@ subsystem_to_name_map_task
 subsystem_to_name_map_thread_act
 subsystem_to_name_map_vm_map
 subsystems
-subsytem
+subsystem
 subtlety
 subtract
 subtract_with_carry


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: cpp

## Description

fixes [#2967](https://github.com/streetsidesoftware/cspell-dicts/issues/2967)

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
