### PR TITLE
fix: Do not add to "words"

### DIFF
--- a/dictionaries/monkeyc/cspell-ext.json
+++ b/dictionaries/monkeyc/cspell-ext.json
@@ -1,11 +1,9 @@
-// cSpell Settings
 {
     "id": "monkeyc",
     "version": "0.2",
     "name": "Monkey C",
     "description": "Monkey C dictionary for cspell.",
     "readonly": true,
-    // List of dictionary files to add to the global list of dictionaries
     "dictionaryDefinitions": [
         {
             "name": "monkeyc",
@@ -13,33 +11,11 @@
             "description": "Monkey C dictionary for cspell."
         }
     ],
-    // Dictionaries to always be used.
-    // Generally left empty
-    "dictionaries": [],
-    // Language Rules to apply to matching files.
-    // Files are matched on `languageId` and `locale`
     "languageSettings": [
         {
-            // VSCode languageId. i.e. typescript, java, go, cpp, javascript, markdown, latex
-            // * will match against any file type.
             "languageId": "monkeyc",
-            // Language locale. i.e. en-US, de-AT, or ru. * will match all locales.
-            // Multiple locales can be specified like: "en, en-US" to match both English and English US.
             "locale": "*",
-            // By default the whole text of a file is included for spell checking
-            // Adding patterns to the "includeRegExpList" to only include matching patterns
-            "includeRegExpList": [],
-            // To exclude patterns, add them to "ignoreRegExpList"
-            "ignoreRegExpList": [],
-            // regex patterns than can be used with ignoreRegExpList or includeRegExpList
-            // Example: "pattern": [{ "name": "mdash", "pattern": "&mdash;" }]
-            // This could be included in "ignoreRegExpList": ["mdash"]
-            "patterns": [],
-            // List of dictionaries to enable by name in `dictionaryDefinitions`
-            "dictionaries": ["monkeyc"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
-            "dictionaryDefinitions": []
+            "dictionaries": ["monkeyc"]
         }
-    ],
-    "words": ["monkeyc"]
+    ]
 }

--- a/dictionaries/monkeyc/cspell.json
+++ b/dictionaries/monkeyc/cspell.json
@@ -8,5 +8,6 @@
     ],
     "import": [
         "./cspell-ext.json"
-    ]
+    ],
+    "words": ["monkeyc"]
 }


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _monkeyc_

## Description

Dictionaries should not add to the global `words`.

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
