### PR TITLE
fix: add "kanban" to software terms

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -857,6 +857,7 @@ jsonrpc
 jumbotron
 junit
 Jupyter
+kanban
 kerberos
 Kerberos
 keybindings


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _software-terms_

## Description

Adds kanban to the software terms dictionary (e.g., https://en.wikipedia.org/wiki/Kanban_board)

## References

- https://en.wikipedia.org/wiki/Kanban_board

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
