### PR TITLE
fix: Remove `persistance` from en_US

### DIFF
--- a/dictionaries/en_US/src/en_US.txt
+++ b/dictionaries/en_US/src/en_US.txt
@@ -14365,7 +14365,7 @@ perpetuators
 perpetuities
 perpetuum
 persecutee
-persistance
+persistence
 persister
 persisters
 persnicketiness


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _en_US_

## Description

fixes #3111


## References

- [persistance - Did you spell it correctly. Alternative spellings in the British English Dictionary - Cambridge Dictionary](https://dictionary.cambridge.org/spellcheck/english/?q=persistance)

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
