### PR TITLE
fix: add `powf` and `powi` to rust dictionary

### DIFF
--- a/dictionaries/rust/src/rust.txt
+++ b/dictionaries/rust/src/rust.txt
@@ -74,6 +74,8 @@ override
 panic
 PartialEq
 PartialOrd
+powf
+powi
 println
 priv
 proc


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: [Rust](https://github.com/streetsidesoftware/cspell-dicts/tree/main/dictionaries/rust)

## Description

This PR adds "powf" and "powi" to the Rust dictionary as they are used for exponentiation for floats.

## References

- https://doc.rust-lang.org/std/primitive.f32.html#method.powf
- https://doc.rust-lang.org/std/primitive.f64.html#method.powi

## Checklist

- [X] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [X] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
