### PR TITLE
fix: add uk dictionary replacement map (`ʼ` -> `'`)

### DIFF
--- a/dictionaries/uk_UA/cspell-ext.json
+++ b/dictionaries/uk_UA/cspell-ext.json
@@ -7,6 +7,7 @@
         {
             "name": "uk-ua",
             "path": "./uk_ua.trie",
+            "repMap": [["ʼ", "'"]],
             "description": "Ukrainian Dictionary",
             "dictionaryInformation": {
                 "locale": "uk-UA",


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: uk-ua

## Description

Replace ʼ to ' for uk dictionary lookups.

## References

Based on https://github.com/brown-uk/dict_uk/issues/317

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
