### PR TITLE
fix: add "kube" to k8s dictionary

### DIFF
--- a/dictionaries/k8s/src/k8s.txt
+++ b/dictionaries/k8s/src/k8s.txt
@@ -310,6 +310,7 @@ key
 keyring
 kind
 konnectivity
+kube
 kubeadm
 kubelet
 kubeletConfigKey


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Fix Dictionary

Dictionary: k8s

## Description

Add "kube" to k8s dictionary

## References

- https://www.redhat.com/en/topics/containers/what-is-kubernetes

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
