### PR TITLE
fix: Enable dictionaries for MDX

### DIFF
--- a/dictionaries/fullstack/cspell-ext.json
+++ b/dictionaries/fullstack/cspell-ext.json
@@ -25,6 +25,7 @@
                 "javascript",
                 "javascriptreact",
                 "lua",
+                "mdx",
                 "php",
                 "python",
                 "ruby",

--- a/dictionaries/markdown/cspell-ext.json
+++ b/dictionaries/markdown/cspell-ext.json
@@ -35,7 +35,7 @@
     ],
     "languageSettings": [
         {
-            "languageId": "markdown",
+            "languageId": "markdown,mdx",
             "locale": "*",
             "ignoreRegExpList": ["MARKDOWN-link-reference", "MARKDOWN-link-footer", "MARKDOWN-link", "MARKDOWN-anchor"],
             "patterns": [],

--- a/dictionaries/typescript/cspell-ext.json
+++ b/dictionaries/typescript/cspell-ext.json
@@ -39,7 +39,7 @@
         {
             // VSCode languageId. i.e. typescript, java, go, cpp, javascript, markdown, latex
             // * will match against any file type.
-            "languageId": "typescript,javascript,typescriptreact,javascriptreact",
+            "languageId": "typescript,javascript,typescriptreact,javascriptreact,mdx",
             // Language locale. i.e. en-US, de-AT, or ru. * will match all locals.
             // Multiple locals can be specified like: "en, en-US" to match both English and English US.
             "locale": "*",


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

## Description

- Enable dictionaries for MDX.
  MDX is Markdown + JavaScript React - the respective settings should be enabled.

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
