### PR TITLE
fix: Add tokio

### DIFF
--- a/dictionaries/rust/src/rust.txt
+++ b/dictionaries/rust/src/rust.txt
@@ -100,6 +100,7 @@ struct
 Sub
 super
 sync
+tokio
 toml
 toolchain
 trait

--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -938,6 +938,7 @@ Levenshtein
 lex
 lexable
 lexed
+lexer
 lexes
 lexing
 lgpl


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: rust

## Description

I noticed that the name of the popular crate `tokio` was missing.

## References

- None

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
