### PR TITLE
fix: Remove lower case `colum` from English dictionaries.

### DIFF
--- a/dictionaries/en-common-misspellings/dict-en.yaml
+++ b/dictionaries/en-common-misspellings/dict-en.yaml
@@ -837,6 +837,7 @@ dictionaryDefinitions:
       - collony->colony
       - collosal->colossal
       - colonizators->colonizers
+      - colum->column
       - comander->commander, commandeer
       - comando->commando
       - comandos->commandos

--- a/dictionaries/en_AU/cspell-tools.config.yaml
+++ b/dictionaries/en_AU/cspell-tools.config.yaml
@@ -10,4 +10,6 @@ targets:
     format: trie3
     targetDirectory: '.'
     generateNonStrict: true
+    excludeWordsFrom:
+      - node_modules/@cspell/dict-en-shared/src/exclude-words.txt
 checksumFile: true

--- a/dictionaries/en_CA/cspell-tools.config.yaml
+++ b/dictionaries/en_CA/cspell-tools.config.yaml
@@ -10,4 +10,6 @@ targets:
     format: trie3
     targetDirectory: '.'
     generateNonStrict: true
+    excludeWordsFrom:
+      - node_modules/@cspell/dict-en-shared/src/exclude-words.txt
 checksumFile: true

--- a/dictionaries/en_GB-MIT/cspell-tools.config.yaml
+++ b/dictionaries/en_GB-MIT/cspell-tools.config.yaml
@@ -9,4 +9,6 @@ targets:
       - listFile: source-files.txt
     sort: true
     generateNonStrict: true
+    excludeWordsFrom:
+      - node_modules/@cspell/dict-en-shared/src/exclude-words.txt
 checksumFile: true

--- a/dictionaries/en_GB/cspell-tools.config.yaml
+++ b/dictionaries/en_GB/cspell-tools.config.yaml
@@ -13,4 +13,6 @@ targets:
       - node_modules/@cspell/dict-en-shared/src/shared-additional-words.txt
     sort: true
     generateNonStrict: true
+    excludeWordsFrom:
+      - node_modules/@cspell/dict-en-shared/src/exclude-words.txt
 checksumFile: true

--- a/dictionaries/en_GB/src/exclude-words.txt
+++ b/dictionaries/en_GB/src/exclude-words.txt
@@ -1,4 +1,0 @@
-~colum
-colum
-knifes
-midwifes

--- a/dictionaries/en_GB/src/exclude-words.txt
+++ b/dictionaries/en_GB/src/exclude-words.txt
@@ -1,2 +1,4 @@
+~colum
+colum
 knifes
 midwifes

--- a/dictionaries/en_US/cspell-tools.config.yaml
+++ b/dictionaries/en_US/cspell-tools.config.yaml
@@ -15,5 +15,5 @@ targets:
     targetDirectory: '.'
     generateNonStrict: true
     excludeWordsFrom:
-      - src/exclude-words.txt
+      - node_modules/@cspell/dict-en-shared/src/exclude-words.txt
 checksumFile: true

--- a/dictionaries/en_US/src/en_US.txt
+++ b/dictionaries/en_US/src/en_US.txt
@@ -3715,7 +3715,7 @@ colors
 colossians
 colossuses
 colporteurs
-columbian
+Columbian
 columnal
 colures
 combater

--- a/dictionaries/en_shared/cspell-tools.config.yaml
+++ b/dictionaries/en_shared/cspell-tools.config.yaml
@@ -3,8 +3,10 @@
 targets:
   - name: 'en-shared'
     sources:
-      - 'src/shared-additional-words.txt'
-    format: 'plaintext'
+      - src/shared-additional-words.txt
+    format: plaintext
     targetDirectory: './dict'
     generateNonStrict: false
     compress: false
+    excludeWordsFrom:
+      - src/exclude-words.txt

--- a/dictionaries/en_shared/src/exclude-words.txt
+++ b/dictionaries/en_shared/src/exclude-words.txt
@@ -1,0 +1,4 @@
+~colum
+colum
+knifes
+midwifes

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "cross-env": "^7.0.3",
     "cspell": "^8.9.0",
     "cspell-dict-file-checker": "workspace:*",
+    "cspell-trie": "^8.9.0",
     "eslint": "^9.5.0",
     "generator-cspell-dicts": "workspace:*",
     "globals": "^15.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       cspell-dict-file-checker:
         specifier: workspace:*
         version: link:cspell-dict-file-checker
+      cspell-trie:
+        specifier: ^8.9.0
+        version: 8.9.0
       eslint:
         specifier: ^9.5.0
         version: 9.5.0
@@ -2715,6 +2718,16 @@ packages:
       '@cspell/cspell-pipe': 8.9.0
       '@cspell/cspell-types': 8.9.0
       gensequence: 7.0.0
+
+  /cspell-trie@8.9.0:
+    resolution: {integrity: sha512-HlvUgV7gWF18aA7yAOiqQcM5CfdhrgX1RAZ7orN00bQ+NQyxPREHP7diajzD/MO6CdkntuCaxWHyT3f1OOm3lg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      commander: 12.1.0
+      cspell-trie-lib: 8.9.0
+      gensequence: 7.0.0
+    dev: true
 
   /cspell@8.9.0:
     resolution: {integrity: sha512-lDYu5p/XU3rqiNjMV46s92yJ7SfVyzAy03OtCJ94fopegZwFLjqZvqoy509ccP/0sHmiv83oTed8LP6Fm3kjpw==}


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: English

## Description

Remove lower case `colum` from the English dictionaries and add a suggestion: `colum->column`.

Related to #3311 

This PR also sets up a common `exclude-words.txt` file to remove words from the English dictionaries.

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
