### PR TITLE
fix: prevent lower case versions of names.

### DIFF
--- a/dictionaries/people-names/checksum.txt
+++ b/dictionaries/people-names/checksum.txt
@@ -1,3 +1,3 @@
-e3bcc41e0e1acc4456f29000493f62d31512c56e  dict/people-names.txt
+fb2475093286ea1f9dfd796dcdcebbb9345688fb  dict/people-names.txt
 b271eba19530fcce9ef5e15c00678127eab74e7c  src/names.txt
 2657c29ad2d375cd0050225eb4cb06ed9175eed2  src/us-census.txt

--- a/dictionaries/people-names/cspell-tools.config.yaml
+++ b/dictionaries/people-names/cspell-tools.config.yaml
@@ -9,4 +9,6 @@ targets:
     targetDirectory: './dict'
     generateNonStrict: false
     compress: false
+    dictionaryDirectives:
+      - no-generate-alternatives
 checksumFile: true

--- a/dictionaries/people-names/dict/people-names.txt
+++ b/dictionaries/people-names/dict/people-names.txt
@@ -1,5 +1,6 @@
 
 # cspell-tools: keep-case no-split
+# cspell-dictionary: no-generate-alternatives
 
 Aamodt
 Aaron

--- a/dictionaries/people-names/package.json
+++ b/dictionaries/people-names/package.json
@@ -11,7 +11,7 @@
     "./cspell-ext.json": "./cspell-ext.json"
   },
   "scripts": {
-    "build": "cross-env NODE_OPTIONS=--max_old_space_size=8192 cspell-tools-cli build",
+    "build": "cspell-tools-cli build",
     "test": "head -n 1000 \"src/names.txt\" | cspell -c ./cspell-ext.json  \"--languageId=*\" stdin",
     "prepublishOnly": "echo OK",
     "prepare:dictionary": "pnpm run build"


### PR DESCRIPTION

<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _people-names_

## Description

This change enforces the correct capitalization of names when spell checking.

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
