### PR TITLE
fix: add missing company acronym for Analog Devices

### DIFF
--- a/dictionaries/companies/src/companies.txt
+++ b/dictionaries/companies/src/companies.txt
@@ -23,6 +23,7 @@ ADBE
 Adblock
 Adecco Group
 AdGuard
+ADI
 Adidas
 Adobe Inc.
 ADSK


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: `companies`

## Description

ADI is the commonly used acronym by Analog Devices employees themselves (hi 👋), it's also all over https://www.analog.com/ and it's the company's stock ticker.

## References

- https://en.wikipedia.org/wiki/Analog_Devices

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
