### PR TITLE
fix: add unsort to the list of software terms

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -1889,6 +1889,7 @@ unselectings
 unselects
 unserializable
 unshare
+unsort
 unsortable
 unsorted
 unstage


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: `softwareTerms`

## Description

This adds the counterpart to `sort`, since we already have `sorted`/`unsorted`, etc.

## References

- This is defined as a computing term in https://en.wiktionary.org/wiki/unsort:
  > To shuffle a data structure so that it is no longer sorted.

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
