### PR TITLE
fix: add lowercase version of `text-rendering` values

### DIFF
--- a/dictionaries/css/src/css.txt
+++ b/dictionaries/css/src/css.txt
@@ -393,6 +393,7 @@ gap
 garamond
 geometric
 geometricPrecision
+geometricprecision
 georgia
 georgian
 ghostwhite
@@ -714,6 +715,8 @@ opentype
 operator
 optgroup
 optimize
+optimizelegibility
+optimizespeed
 option
 optional
 orange


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: css

## Description and references

Although https://developer.mozilla.org/en-US/docs/Web/CSS/text-rendering still lists these values with a camelCase, the CSS/SVG specs are progressively moving all their values to lowercase. For example, [`currentcolor` has now fully replaced `currentColor`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).

Stylelint's standard configuration enforces using `optimizelegibility`, etc. and this conversation explains why: https://github.com/stylelint/stylelint/issues/1089#issuecomment-1027060009

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
