### PR TITLE
fix: PowerShell add Runspace(s)

### DIFF
--- a/dictionaries/powershell/src/powershell.txt
+++ b/dictionaries/powershell/src/powershell.txt
@@ -547,3 +547,5 @@ www
 xml
 xor
 z
+runspace
+runspaces


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Fix PowerShell dict
Resolves #3540 

## Description

Add `runspace` and `runspaces` to PowerShell dict

## References

- _Any source references._

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
