### PR TITLE
fix: Add new Shadow Root related HTML attributes

### DIFF
--- a/dictionaries/html/src/html.txt
+++ b/dictionaries/html/src/html.txt
@@ -2531,6 +2531,10 @@ Sfr
 sfrown
 sgml
 shadowroot
+shadowrootclonable
+shadowrootdelegatesfocus
+shadowrootmode
+shadowrootserializable
 sharp
 shchcy
 SHCHcy


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: HTML

## Description

Adds new Shadow Root related HTML attributes.

## References

- There are [four new attributes](https://html.spec.whatwg.org/multipage/scripting.html#the-template-element) for the `<template>` element. And the `shadowroot` has been renamed to `shadowrootmode`.

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix