### PR TITLE
fix: add `-isnot` to powershell dictionary fixes streetsidesoftware/cspell-dicts#3577

### DIFF
--- a/dictionaries/powershell/src/powershell.txt
+++ b/dictionaries/powershell/src/powershell.txt
@@ -1,5 +1,6 @@
 # Keywords and terms related to Powershell
 # Please add new words after this line, one word per line.
+-isnot
 [Microsoft.PowerShell.ExecutionPolicy]::AllSigned
 [Microsoft.PowerShell.ExecutionPolicy]::Bypass
 [Microsoft.PowerShell.ExecutionPolicy]::Default


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: PowerShell

## Description

Adds `-isnot` to the PowerShell dictionary

## References

- [https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.4#type-comparison](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.4#type-comparison)

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
