### PR TITLE
fix: Recognize bash strict mode arguments

### DIFF
--- a/dictionaries/bash/dict/bash-words.txt
+++ b/dictionaries/bash/dict/bash-words.txt
@@ -102,6 +102,7 @@ enable
 errexit
 errtrace
 esac
+euxo
 eval
 exec
 exit

--- a/dictionaries/bash/src/bash-words.txt
+++ b/dictionaries/bash/src/bash-words.txt
@@ -41,6 +41,7 @@ errexit
 errtrace
 esac
 EUID
+euxo
 eval
 exec
 EXECIGNORE


### PR DESCRIPTION
Bash strict mode is a very popular command `set -euxo pipefail` which
generates a false positives with cspell.

See: http://redsymbol.net/articles/unofficial-bash-strict-mode/

<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _dictionary_

## Description

_description of change_

## References

- _Any source references._

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
