### PR TITLE
fix: add testid to the list of coding terms

### DIFF
--- a/dictionaries/software-terms/src/coding-terms.txt
+++ b/dictionaries/software-terms/src/coding-terms.txt
@@ -580,6 +580,7 @@ terms
 testcase
 testcases
 testEnv
+testid
 testfile
 testfiles
 testMessage


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _software-terms_

## Description

This is (too) commonly used when testing software, such as [here](https://testing-library.com/docs/queries/bytestid/). This is often used in the context of a HTML data attribute, e.g. `data-testid="foo"` which CSpell flags as an error.

## References

I followed the advice listed at https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/software-terms/src/software-terms.txt#L5, let me know if you'd prefer me to add this to a different file.

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
