### PR TITLE
fix: Add "maxsplit" to python.txt dictionary

### DIFF
--- a/dictionaries/python/dict/python.txt
+++ b/dictionaries/python/dict/python.txt
@@ -6308,6 +6308,7 @@ maxlen
 maxline
 maxminddb
 maxsize
+maxsplit
 maybe
 maybesave
 mb

--- a/dictionaries/python/dict/python.txt
+++ b/dictionaries/python/dict/python.txt
@@ -6308,7 +6308,6 @@ maxlen
 maxline
 maxminddb
 maxsize
-maxsplit
 maybe
 maybesave
 mb

--- a/dictionaries/python/src/python/python.txt
+++ b/dictionaries/python/src/python/python.txt
@@ -517,6 +517,7 @@ mark
 marshal
 math
 max
+maxsplit
 mbcs
 mccabe
 MemoryError


### PR DESCRIPTION

<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: python.txt

## Description

The `split` method in the `re` package has a keyword argument `maxsplit`.

## References

https://docs.python.org/3/library/re.html#re.split

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
