### PR TITLE
fix: add azdo to coding-terms.txt

### DIFF
--- a/dictionaries/software-terms/src/coding-terms.txt
+++ b/dictionaries/software-terms/src/coding-terms.txt
@@ -80,6 +80,7 @@ autoMocks
 autoproxy
 autoScroll
 autoSpy
+azdo # Azure DevOps
 azureCR # (Azure Container Registry)
 azureRM # (Azure Resource Manager)
 azureTools


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: software-terms

## Description

This adds the term `azdo`, which is a common abbreviation for Azure DevOps. Thanks!

## References

- https://learn.microsoft.com/en-us/azure/devops/extend/publish/overview?view=azure-devops#prerequisites

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
