### PR TITLE
fix: add hadolint to docker dictionary

### DIFF
--- a/dictionaries/docker/src/docker-words.txt
+++ b/dictionaries/docker/src/docker-words.txt
@@ -30,6 +30,7 @@ exec
 EXPOSE
 from
 FROM
+hadolint
 HEALTHCHECK
 image
 interval


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: docker

## Description

This adds `hadolint` to the docker dictionary, which is a popular Dockerfile linter.

## References

- [_Any source references._](https://github.com/hadolint/hadolint)

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
