### PR TITLE
fix: add zdotdir to shell dictionary

### DIFF
--- a/dictionaries/bash/src/bash-words.txt
+++ b/dictionaries/bash/src/bash-words.txt
@@ -189,3 +189,4 @@ vi
 wait
 while
 xtrace
+zdotdir

--- a/dictionaries/bash/src/bash-words.txt
+++ b/dictionaries/bash/src/bash-words.txt
@@ -189,4 +189,3 @@ vi
 wait
 while
 xtrace
-zdotdir

--- a/dictionaries/shell/src/shell-zsh-words.txt
+++ b/dictionaries/shell/src/shell-zsh-words.txt
@@ -19,5 +19,6 @@ setopt
 strftime
 tabtab
 unsetopt
+zdotdir
 zshconfig
 zstyle


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: bash

## Description

This adds `zdotdir` to the bash dictionary, which is a variable used by zsh.

## References

- https://zsh.sourceforge.io/Guide/zshguide02.html

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
