### PR TITLE
fix: add all-contributorsrc to software-tools.txt

### DIFF
--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -5,7 +5,7 @@ airbrake
 AirWatch
 AKS
 Alibaba
-all-contributorsrc
+all-contributorsrc # Configuration file used by the All Contributors CLI
 anaconda
 Android
 Anka

--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -5,6 +5,7 @@ airbrake
 AirWatch
 AKS
 Alibaba
+all-contributorsrc
 anaconda
 Android
 Anka


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: software-terms

## Description

This adds `all-contributorsrc` which is the name of the config file used by the All Contributors CLI/GitHub bot.

## References

- https://allcontributors.org/docs/en/bot/configuration

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
