### PR TITLE
fix: Add Astro to TypeScript dictionary settings

### DIFF
--- a/dictionaries/filetypes/src/filetypes.txt
+++ b/dictionaries/filetypes/src/filetypes.txt
@@ -381,3 +381,4 @@ zsh
 zshenv
 zshrc
 zshtheme
+astro

--- a/dictionaries/typescript/cspell-ext.json
+++ b/dictionaries/typescript/cspell-ext.json
@@ -1,20 +1,16 @@
-// cSpell Settings
 {
     "id": "typescript",
     "name": "TypeScript",
-    "description": "TypeScript and JavaScript dictionary for cspell.",
+    "description": "TypeScript and JavaScript dictionary for CSpell.",
     "readonly": true,
     // List of dictionary files to add to the global list of dictionaries
     "dictionaryDefinitions": [
         {
             "name": "typescript",
             "path": "./dict/typescript.txt",
-            "description": "TypeScript and JavaScript dictionary for cspell."
+            "description": "TypeScript and JavaScript dictionary for CSpell."
         }
     ],
-    // Dictionaries to always be used.
-    // Generally left empty
-    "dictionaries": [],
     // Patterns
     "patterns": [
         {
@@ -33,29 +29,23 @@
             "description": "JavaScript Match Regular Expression Flags"
         }
     ],
-    // Language Rules to apply to matching files.
-    // Files are matched on `languageId` and `locale`
     "languageSettings": [
         {
-            // VSCode languageId. i.e. typescript, java, go, cpp, javascript, markdown, latex
-            // * will match against any file type.
-            "languageId": "typescript,javascript,typescriptreact,javascriptreact,mdx",
-            // Language locale. i.e. en-US, de-AT, or ru. * will match all locals.
-            // Multiple locals can be specified like: "en, en-US" to match both English and English US.
+            "languageId": "typescript,javascript,typescriptreact,javascriptreact,mdx,astro",
             "locale": "*",
-            // By default the whole text of a file is included for spell checking
-            // Adding patterns to the "includeRegExpList" to only include matching patterns
-            "includeRegExpList": [],
-            // To exclude patterns, add them to "ignoreRegExpList"
             "ignoreRegExpList": ["js-hex-escape", "js-unicode-escape", "js-regexp-flags"],
-            // regex patterns than can be used with ignoreRegExpList or includeRegExpList
-            // Example: "pattern": [{ "name": "mdash", "pattern": "&mdash;" }]
-            // This could be included in "ignoreRegExpList": ["mdash"]
-            "patterns": [],
-            // List of dictionaries to enable by name in `dictionaryDefinitions`
-            "dictionaries": ["typescript"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
-            "dictionaryDefinitions": []
+            "dictionaries": ["typescript"]
+        },
+        {
+            "languageId": "astro",
+            "dictionaries": ["html", "html-symbol-entities"]
         }
-    ]
+    ],
+    "overrides": [
+        {
+            "filename": "**/*.astro",
+            "languageId": "astro" // set the file type to be Astro
+        }
+    ],
+    "enabledLanguageIds": ["astro"]
 }

--- a/dictionaries/typescript/dict/typescript.txt
+++ b/dictionaries/typescript/dict/typescript.txt
@@ -7,6 +7,7 @@ ANISOTROPY
 AnimationEvent
 Array
 ArrayBuffer
+Astro
 AsyncFunction
 Atomics
 BYTES_PER_ELEMENT

--- a/dictionaries/typescript/samples/asmple.astro
+++ b/dictionaries/typescript/samples/asmple.astro
@@ -1,0 +1,8 @@
+---
+const name = "Astro";
+---
+<h1 class={name}>Attribute expressions are supported</h1>
+
+<div>
+    <h1>Hello {name}!</h1>  <!-- Outputs <h1>Hello Astro!</h1> -->
+</div>

--- a/dictionaries/typescript/src/ecosystem-terms.txt
+++ b/dictionaries/typescript/src/ecosystem-terms.txt
@@ -2,3 +2,4 @@
 # Contains terms that will be encountered while working in the TypeScript/JavaScript ecosystem.
 bindgen # related to importing Rust into WASM
 WebAssembly
+Astro


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _typescript_

## Description

fixes #3712


## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
