### PR TITLE
fix(terraform): add alltrue to allowed words

### DIFF
--- a/dictionaries/terraform/src/terraform.txt
+++ b/dictionaries/terraform/src/terraform.txt
@@ -1,4 +1,5 @@
 abs
+alltrue
 chomp
 cidrhost
 cidrnetmask


### PR DESCRIPTION
Available in [version 0.14](https://developer.hashicorp.com/terraform/language/functions/alltrue)

<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix(terraform): add alltrue to allowed words'
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: terraform

## Description

add alltrue

## References

Available in [version 0.14](https://developer.hashicorp.com/terraform/language/functions/alltrue)


## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
