### PR TITLE
fix: add `tstyche` to npm dictionary

### DIFF
--- a/dictionaries/npm/src/npm.txt
+++ b/dictionaries/npm/src/npm.txt
@@ -1,6 +1,7 @@
 # This is a list of some of the top (and not so top) packages at https://npmjs.com
 # This should only include NPM packages. Please put other terms in another location.
 # To add a new packages, just add it after this line, it wil get automatically sorted.
+tstyche
 @11ty/eleventy
 @adobe/css-tools
 @adonisjs/core


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: npm

## Description

TSTyche is a big fan of CSpell. I am using the spell checker from the first days of [the repo](https://github.com/tstyche/tstyche). Would it be possible to include it in the npm dictionary?

## References

Package page: https://www.npmjs.com/package/tstyche

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
