### PR TITLE
fix: add lockb to filetypes

### DIFF
--- a/dictionaries/filetypes/src/filetypes.txt
+++ b/dictionaries/filetypes/src/filetypes.txt
@@ -176,6 +176,7 @@ latn
 launch
 lcov
 less
+lockb
 lua
 m
 m4a


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: filetypes

## Description

lockb is the file extension for Bun's lock file.
Bun is a popular package manager for JavaScript/TypeScript.

## References

https://bun.sh/docs/install/lockfile

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
