### PR TITLE
chore: add docs on proposing words

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,10 @@ Please feel free to contribute to this project.
 - Creating new dictionaries.
 - Filing any issues related to using dictionaries.
 - Assisting in answering issues.
+
+## Proposing Words
+
+If you have a word you believe belongs in a dictionary, send a pull request.
+For words associated with a particular programming language / environment, they should go in the appropriate dictionary under `dictionaries/<language>`(s).
+For general-purpose words, put them in the closest appropriate `dictionaries/<general-area>`(s).
+See the `README.md` files in those directories for more information.


### PR DESCRIPTION
## Description

Copies the intent from https://github.com/streetsidesoftware/cspell-dicts/issues/3866#issuecomment-2538251022 into docs.

## References

https://github.com/streetsidesoftware/cspell-dicts/issues/3866#issuecomment-2538251022

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.

I would have used `docs:` as the prefix, but it's not on the checklist.