### PR TITLE
fix: add a few coding and software terms

### DIFF
--- a/dictionaries/companies/src/companies.txt
+++ b/dictionaries/companies/src/companies.txt
@@ -998,6 +998,7 @@ Ko-fi
 Kobe Steel
 Kohl's Corporation
 Komatsu
+Konami
 Koo Holding
 Korea Electric Power
 Korea Gas

--- a/dictionaries/gaming-terms/src/gaming-terms.txt
+++ b/dictionaries/gaming-terms/src/gaming-terms.txt
@@ -16,6 +16,7 @@ Headshots
 Hitpoint
 Hitscan
 JRPG
+konami
 Leaderboard
 Mana
 Matchmaking

--- a/dictionaries/software-terms/src/coding-terms.txt
+++ b/dictionaries/software-terms/src/coding-terms.txt
@@ -74,6 +74,7 @@ autofixer
 autofixes
 autofixing
 autoLoader
+automerge
 autoMock
 autoMocking
 autoMocks
@@ -529,6 +530,7 @@ onversionchange
 orderId
 outBuffer
 outDir
+outro
 pageData
 pageView
 pageViews
@@ -702,6 +704,7 @@ sysKeyDown
 sysRoot
 sysRoots
 tabpanel
+tada
 tarFile
 tBody
 tChar
@@ -850,6 +853,7 @@ webserver
 widgetManager
 WindowsLogin
 wireframe
+wontfix
 workArea
 workDir
 workFolder

--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -935,6 +935,7 @@ keyframes
 keyscan
 keyscans
 Knuth
+konami
 Kotlin
 KotlinScript
 Kramdown

--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -935,7 +935,6 @@ keyframes
 keyscan
 keyscans
 Knuth
-konami
 Kotlin
 KotlinScript
 Kramdown


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: _coding-terms_, _software-terms_

## Description

Adds the following terms:

* `coding-terms`:
    * `automerge`
    * `outro`
    * `tada`
    * `wontfix`
* `software-terms`
    * `konami`

## References

* `konami`: https://en.wikipedia.org/wiki/Konami_Code
* `outro`: https://en.wiktionary.org/wiki/outro
* `tada`: https://en.wikipedia.org/wiki/Party_popper#:~:text=tada

For `automerge` and `wontfix`, I don't have specific references to share, but they're pretty common slang that I've used. Is that acceptable? 🙂 

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
