### PR TITLE
fix: Add word preid to npm dictionary

### DIFF
--- a/dictionaries/npm/src/npm-keywords.txt
+++ b/dictionaries/npm/src/npm-keywords.txt
@@ -13,6 +13,7 @@ name
 npmpackagejsonlint
 npmpackagejsonlintignore
 npmpackagejsonlintrc
+preid
 publishConfig
 repository
 scripts


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: _npm_

- `preid`: Command `npm version` has an prerelease identifier option `--preid` to use as a prefix for the "prerelease" part of a SemVer.

   Like the `alpha` in `1.0.0-alpha.1`.

## Description

Add `preid` word for option `--preid` from `npm version` command.

## References

[NPM documentation about `preid`](https://docs.npmjs.com/cli/v8/commands/npm-version#preid)

## Checklist

- [X] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [X] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
