### PR TITLE
fix: add Bluesky and Emojipedia to companies dictionary

### DIFF
--- a/dictionaries/companies/src/companies.txt
+++ b/dictionaries/companies/src/companies.txt
@@ -239,6 +239,7 @@ BlackRock
 BlackRock, Inc.
 Bloomberg
 Bloomreach, Inc.
+Bluesky
 BMW
 BNP Paribas
 Boeing
@@ -600,6 +601,7 @@ EMCOR Group, Inc.
 Emerson Electric
 Emerson Electric Co.
 Emerson Electric Company
+Emojipedia
 Emory University
 Enel
 Energie Baden-Wurttemberg


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: _companies_

## Description

Adds Bluesky and Emojipedia to the list.

## References

* https://bsky.app
* https://emojipedia.org

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
