### PR TITLE
Add missing companies + tech terms

### DIFF
--- a/dictionaries/companies/src/companies.txt
+++ b/dictionaries/companies/src/companies.txt
@@ -38,6 +38,7 @@ AGCO Corporation
 Agilent Technologies Inc
 Agilent Technologies, Inc.
 Agricultural Bank of China
+AICPA
 Air France-KLM Group
 Air Products & Chemicals Inc
 Air Products & Chemicals, Inc.
@@ -337,6 +338,7 @@ China State Construction Engineering
 China Telecommunications
 China United Network Communications
 Chipotle Mexican Grill
+Chocolately
 Christian Dior
 CHRW
 CHS
@@ -927,7 +929,6 @@ Lilly (Eli) & Co.
 Lincoln National
 Lincoln National Corporation
 Linde plc
-LinkedIn
 LinkedIn
 Live Nation Entertainment
 Live Nation Entertainment, Inc.

--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -106,11 +106,14 @@ openvpn
 OpenVPN
 openvz
 OpenVZ
+Pentoo
 php
 pidora
 Podman
 PostgresSQL
+ptrace
 PyCharm
+runc
 Secretlint
 secretlintignore
 Sharpier


### PR DESCRIPTION
Add a few new terms and remove a duplicate LinkedIn entry

<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary:

- software-tools.txt
- companies.txt

## Description

- Remove duplicate LinkedIn companies.txt entry
- Add Chocolatey to companies.txt (https://chocolatey.org/)
- Add AICPA to companies.txt (https://www.aicpa-cima.com)
- Add Pentoo to software-tools.txt (https://www.pentoo.ch/)
- Add ptrace to software-tools.txt (https://man7.org/linux/man-pages/man2/ptrace.2.html)
- add runc to software-tools.txt (https://github.com/opencontainers/runc)

## References

- _Any source references._

## Checklist

- [ ] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [ ] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
