### PR TITLE
fix: Add missing companies + software tool terms

### DIFF
--- a/dictionaries/companies/src/companies.txt
+++ b/dictionaries/companies/src/companies.txt
@@ -46,6 +46,7 @@ AGCO Corporation
 Agilent Technologies Inc
 Agilent Technologies, Inc.
 Agricultural Bank of China
+AICPA
 Air France-KLM Group
 Air Products & Chemicals Inc
 Air Products & Chemicals, Inc.
@@ -77,6 +78,7 @@ Allstate Corp
 Ally Financial Inc.
 Alphabet Inc.
 Alstom
+Altri
 Altria Group Inc
 Altria Group, Inc.
 Aluminum Corp. of China
@@ -377,6 +379,7 @@ China Telecommunications
 China United Network Communications
 Chinese University of Hong Kong
 Chipotle Mexican Grill
+Chocolately
 Christian Dior
 CHRW
 CHS

--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -74,6 +74,7 @@ arraylength
 asc
 asciidoc
 asin
+ASLR
 asm
 assembly
 associable

--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -243,6 +243,7 @@ Ouroboros
 OXSecurity
 pbcopy
 pbpaste
+Pentoo
 perl
 php
 Pidora
@@ -262,6 +263,7 @@ Promxy
 proselint
 proselintrc
 pspings
+ptrace
 PyCharm
 qmake
 Redis
@@ -272,6 +274,7 @@ rmwc
 robocopy
 rsyslog
 rsyslogd
+runc
 rustfix
 rustfmt
 scapy


### PR DESCRIPTION
Add a few new terms and remove a duplicate LinkedIn entry

<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary:

- software-tools.txt
- software-terms.txt
- companies.txt

## Description

- Remove duplicate LinkedIn companies.txt entry
- Add Chocolatey to companies.txt (https://chocolatey.org/)
- Add AICPA to companies.txt (https://www.aicpa-cima.com)
- Add Pentoo to software-tools.txt (https://www.pentoo.ch/)
- Add ptrace to software-tools.txt (https://man7.org/linux/man-pages/man2/ptrace.2.html)
- Add runc to software-tools.txt (https://github.com/opencontainers/runc)
- Add Altri to companies.txt (https://altri.pt)
- Add ASLR to software-terms.txt (https://en.wikipedia.org/wiki/Address_space_layout_randomization)

## References

- _Any source references._

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
