### PR TITLE
fix: make it easier to turn off dictionary

### DIFF
--- a/dictionaries/city-names-finland/cspell-ext.json
+++ b/dictionaries/city-names-finland/cspell-ext.json
@@ -1,4 +1,3 @@
-// cSpell Settings
 {
     "id": "city-names-finland",
     "name": "Cities of Finland",
@@ -13,31 +12,5 @@
         }
     ],
     // Dictionaries to always be used.
-    // Generally left empty
-    "dictionaries": [],
-    // Language Rules to apply to matching files.
-    // Files are matched on `languageId` and `locale`
-    "languageSettings": [
-        {
-            // VSCode languageId. i.e. typescript, java, go, cpp, javascript, markdown, latex
-            // * will match against any file type.
-            "languageId": "*",
-            // Language locale. i.e. en-US, de-AT, or ru. * will match all locals.
-            // Multiple locals can be specified like: "en, en-US" to match both English and English US.
-            "locale": "*",
-            // By default the whole text of a file is included for spell checking
-            // Adding patterns to the "includeRegExpList" to only include matching patterns
-            "includeRegExpList": [],
-            // To exclude patterns, add them to "ignoreRegExpList"
-            "ignoreRegExpList": [],
-            // regex patterns than can be used with ignoreRegExpList or includeRegExpList
-            // Example: "pattern": [{ "name": "mdash", "pattern": "&mdash;" }]
-            // This could be included in "ignoreRegExpList": ["mdash"]
-            "patterns": [],
-            // List of dictionaries to enable by name in `dictionaryDefinitions`
-            "dictionaries": ["city-names-finland"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
-            "dictionaryDefinitions": []
-        }
-    ]
+    "dictionaries": ["city-names-finland"]
 }

--- a/dictionaries/people-names/cspell-ext.json
+++ b/dictionaries/people-names/cspell-ext.json
@@ -14,31 +14,5 @@
         }
     ],
     // Dictionaries to always be used.
-    // Generally left empty
-    "dictionaries": [],
-    // Language Rules to apply to matching files.
-    // Files are matched on `languageId` and `locale`
-    "languageSettings": [
-        {
-            // VSCode languageId. i.e. typescript, java, go, cpp, javascript, markdown, latex
-            // * will match against any file type.
-            "languageId": "*",
-            // Language locale. i.e. en-US, de-AT, or ru. * will match all locales.
-            // Multiple locales can be specified like: "en, en-US" to match both English and English US.
-            "locale": "*",
-            // By default the whole text of a file is included for spell checking
-            // Adding patterns to the "includeRegExpList" to only include matching patterns
-            "includeRegExpList": [],
-            // To exclude patterns, add them to "ignoreRegExpList"
-            "ignoreRegExpList": [],
-            // regex patterns than can be used with ignoreRegExpList or includeRegExpList
-            // Example: "pattern": [{ "name": "mdash", "pattern": "&mdash;" }]
-            // This could be included in "ignoreRegExpList": ["mdash"]
-            "patterns": [],
-            // List of dictionaries to enable by name in `dictionaryDefinitions`
-            "dictionaries": ["people-names"],
-            // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
-            "dictionaryDefinitions": []
-        }
-    ]
+    "dictionaries": ["people-names"]
 }


### PR DESCRIPTION
Dictionaries that are enabled in `languageSettings` are harder to disable than the ones enabled in the root `dictionaries`.

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
