### PR TITLE
chore: default to node 22

### DIFF
--- a/.github/actions/quick-setup/action.yaml
+++ b/.github/actions/quick-setup/action.yaml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     required: false
     description: The version of Node to use.
-    default: '18.x'
+    default: '22.x'
 runs:
   using: 'composite'
   steps:

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     required: false
     description: The version of Node to use.
-    default: '18.x'
+    default: '22.x'
 runs:
   using: 'composite'
   steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
           - 18.x
           - 20.x
           - 22.x
+          - 23.x
 
         os:
           - ubuntu-latest
@@ -39,7 +40,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 18.x
+          - 22.x
 
         os:
           - windows-latest


### PR DESCRIPTION

## Description

- Use Node 22.x as the default instead of Node 18.x.
- Use Node 22.x when testing Windows.


## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
