### PR TITLE
feat: remove `enableFiletypes`

### DIFF
--- a/dictionaries/ada/cspell.json
+++ b/dictionaries/ada/cspell.json
@@ -6,7 +6,6 @@
     "dictionaries": [
         "ada"
     ],
-    "enableFiletypes": ["ada"],
     "import": [
         "./cspell-ext.json"
     ]

--- a/dictionaries/al/cspell-ext.json
+++ b/dictionaries/al/cspell-ext.json
@@ -12,7 +12,6 @@
         }
     ],
     "dictionaries": [],
-    "enableFiletypes": ["al"],
     "languageSettings": [
         {
             "languageId": "al",

--- a/dictionaries/dart/cspell-ext.json
+++ b/dictionaries/dart/cspell-ext.json
@@ -12,7 +12,6 @@
         }
     ],
     "dictionaries": [],
-    "enableFiletypes": ["dart"],
     "languageSettings": [
         {
             "languageId": "dart",

--- a/dictionaries/elisp/cspell.json
+++ b/dictionaries/elisp/cspell.json
@@ -6,6 +6,5 @@
     "import": [
         "./cspell-ext.json"
     ],
-    "enableFiletypes": ["elisp", "lisp"],
     "overrides": [{ "filename": "**/*.{md,txt}", "dictionaries": ["elisp"]}]
 }

--- a/dictionaries/flutter/cspell-ext.json
+++ b/dictionaries/flutter/cspell-ext.json
@@ -12,7 +12,6 @@
         }
     ],
     "dictionaries": [],
-    "enableFiletypes": ["dart"],
     "languageSettings": [
         {
             "languageId": "dart",

--- a/dictionaries/fsharp/cspell-ext.json
+++ b/dictionaries/fsharp/cspell-ext.json
@@ -12,7 +12,6 @@
         }
     ],
     "dictionaries": [],
-    "enableFiletypes": ["fsharp"],
     "languageSettings": [
         {
             "languageId": "fsharp",

--- a/dictionaries/julia/cspell-ext.json
+++ b/dictionaries/julia/cspell-ext.json
@@ -11,7 +11,6 @@
             "description": "Julia Dictionary"
         }
     ],
-    "enableFiletypes": ["julia"],
     "languageSettings": [
         {
             "languageId": "julia",

--- a/dictionaries/kotlin/cspell-ext.json
+++ b/dictionaries/kotlin/cspell-ext.json
@@ -12,7 +12,6 @@
             "description": "Kotlin dictionary."
         }
     ],
-    "enabledLanguageIds": ["kotlin"],
     "languageSettings": [
         {
             "languageId": "kotlin",

--- a/dictionaries/r/cspell-ext.json
+++ b/dictionaries/r/cspell-ext.json
@@ -17,6 +17,5 @@
             "locale": "*",
             "dictionaries": ["r"]
         }
-    ],
-    "enableFiletypes": ["r"]
+    ]
 }

--- a/dictionaries/sql/cspell-ext.json
+++ b/dictionaries/sql/cspell-ext.json
@@ -31,6 +31,5 @@
             "ignoreRegExpList": ["sql-hex-number", "sql-unicode-string-prefix"],
             "dictionaryDefinitions": []
         }
-    ],
-    "enableFiletypes": ["sql"]
+    ]
 }

--- a/dictionaries/terraform/cspell-ext.json
+++ b/dictionaries/terraform/cspell-ext.json
@@ -21,6 +21,5 @@
             "dictionaries": ["terraform"]
         }
     ],
-    "enableFiletypes": ["terraform"],
     "overrides": [{ "filename": "**/*.tf", "languageId": "terraform" }]
 }

--- a/dictionaries/typescript/cspell-ext.json
+++ b/dictionaries/typescript/cspell-ext.json
@@ -46,6 +46,5 @@
             "filename": "**/*.astro",
             "languageId": "astro" // set the file type to be Astro
         }
-    ],
-    "enabledLanguageIds": ["astro"]
+    ]
 }


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: `ada`, `al`, `astro`, `dart`, `elisp`, `lisp`, `fsharp`, `julia`, `kotlin`, `r`, `sql` and `terraform`
 
## Description

Removing `enableFiletypes` from all the dictionary extensions. It is creating confusion.

This is related to: [enabledFileTypes "*": false does not function correctly](https://github.com/streetsidesoftware/vscode-spell-checker/issues/3836#issuecomment-2577830227)

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
