### PR TITLE
fix: add `nodenext`

### DIFF
--- a/dictionaries/fullstack/src/fullstack.txt
+++ b/dictionaries/fullstack/src/fullstack.txt
@@ -264,6 +264,7 @@ ngui
 nicky
 nocache
 nocursor
+nodenext
 noexcept
 nohost
 noindex


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: fullstack

## Description

Add `nodenext` to the `fullstack` dictionary.

## References

Not sure if the `fullstack` dictionary is the best place to add `nodenext`. The dictionary already has `esnext`, so perhaps `nodenext` could also live here too. Or?

`nodenext` can be set as a value of [`module`](https://www.typescriptlang.org/tsconfig/#module) or [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) options of TSConfig file. (Very similarly `esnext` can be set as a value of `module` or `target` options.)

Currently `cspell` does not allow to use `nodenext` in a TSConfig file or code base.

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
