### PR TITLE
fix: Make sure files of type `tf` use `terraform` dict

### DIFF
--- a/dictionaries/terraform/cspell-ext.json
+++ b/dictionaries/terraform/cspell-ext.json
@@ -13,7 +13,7 @@
     ],
     "languageSettings": [
         {
-            "languageId": "terraform,tfvars",
+            "languageId": "terraform,tf,tfvars",
             "locale": "*",
             "includeRegExpList": [],
             "ignoreRegExpList": [],


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: terraform

## Description

The default file type of a terraform `.tf` file reported by VS Code is `tf`, not `terraform`.
This change makes sure that the dictionary will be used in that case.

fixes: https://github.com/streetsidesoftware/vscode-spell-checker/issues/4166

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
