### PR TITLE
fix: Add Samba-related words

### DIFF
--- a/dictionaries/software-terms/src/coding-terms.txt
+++ b/dictionaries/software-terms/src/coding-terms.txt
@@ -134,6 +134,7 @@ borked # https://en.wiktionary.org/wiki/borked
 bottomLeft
 bottomRight
 braceless
+browseable
 browserConfig
 browserstack
 bSize
@@ -656,6 +657,7 @@ rulesdirs
 ruleset
 rulesets
 runtimes
+samaba
 sameSite
 schemeId
 screenShare
@@ -684,6 +686,8 @@ sLen # often string length
 slotId
 smalloc
 smarttabs
+smbclient
+smbpasswd
 snapshotted
 snapshotter
 snapshotting

--- a/dictionaries/software-terms/src/coding-terms.txt
+++ b/dictionaries/software-terms/src/coding-terms.txt
@@ -687,6 +687,7 @@ slotId
 smalloc
 smarttabs
 smbclient
+smbd
 smbpasswd
 snapshotted
 snapshotter


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: coding-terms.txt

## Description

Added some Samba-related words.

## References

- [browseable](https://www.samba.org/samba/docs/4.9/man-html/smb.conf.5.html)
- [samba](https://www.samba.org/)
- [smbclient](https://www.samba.org/samba/docs/4.9/man-html/smbclient.1.html)
- [smbd](https://www.samba.org/samba/docs/4.17/man-html/smbd.8.html)
- [smbpasswd](https://www.samba.org/samba/docs/4.9/man-html/smbpasswd.8.html)

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
