### PR TITLE
fix: Fix typo of indentless_arrays

### DIFF
--- a/dictionaries/software-terms/src/coding-terms.txt
+++ b/dictionaries/software-terms/src/coding-terms.txt
@@ -383,7 +383,7 @@ iifes # Immediately Invoked Function Expressions
 imageSize
 importLib
 inBuffer
-indentless_array
+indentless_arrays
 indexFile
 instanceDir
 instanceof


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: coding-terms.txt

## Description

Sorry, I made a typo in https://github.com/streetsidesoftware/cspell-dicts/pull/4159.

## References

- [indentless_arrays](https://github.com/google/yamlfmt/blob/928ce33e9afa338486d889549fc78e6b7feabeaf/docs/config-file.md)

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
