### PR TITLE
fix: Add "succumber", "succumbence", and "succumbency" to the en_shared dictionary to complement the existing.

### DIFF
--- a/dictionaries/en_shared/src/shared-additional-words.txt
+++ b/dictionaries/en_shared/src/shared-additional-words.txt
@@ -119,6 +119,7 @@ sorcerous
 springform
 succumbence
 succumbency
+succumber
 sweetgrass
 swiper
 topline

--- a/dictionaries/en_shared/src/shared-additional-words.txt
+++ b/dictionaries/en_shared/src/shared-additional-words.txt
@@ -117,6 +117,8 @@ screencast
 shoshin
 sorcerous
 springform
+succumbence
+succumbency
 sweetgrass
 swiper
 topline


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: en_shared

## Description

Add "succumber" to the en_shared dictionary to complement the existing "succumbence" and "succumbency" words.

## References

- Dictionary.com lists "succumber" as a derived form of "succumb": https://www.dictionary.com/browse/succumb

## Checklist

- [x] By submitting this pull-request, I agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - [x] `fix:` - for minor changes like adding words or fixing spelling issues.
  - [ ] `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - [ ] `feat!:` - for breaking changes, like file format or licensing changes.
  - [ ] `chore:` - for changes that do not impact the content of dictionaries. 
