### PR TITLE
fix: add attw, markdownlintignore, npmjs words

### DIFF
--- a/dictionaries/node/src/node.txt
+++ b/dictionaries/node/src/node.txt
@@ -52,6 +52,7 @@ node::ObjectWrap
 node::ObjectWrap::Unwrap
 node.h
 npm
+npmjs
 npm install
 npm install -g node-gyp
 plusOne()

--- a/dictionaries/npm/src/npm.txt
+++ b/dictionaries/npm/src/npm.txt
@@ -499,6 +499,7 @@ async-listen
 async-retry
 async-validator
 atob
+attw
 aud
 auto-changelog
 auto-install

--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -186,6 +186,7 @@ Mandriva
 Mangeia
 Manjaro
 markdownlint
+markdownlintignore
 MegaLinter
 Microsoft
 minikube


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: _node_, _npm_, _software-tools_

## Description

Adds:

* `attw`: the bin commanded set by https://www.npmjs.com/package/@arethetypeswrong/cli
* `markdownlintignore`: the standard ignore file for https://github.com/igorshubovych/markdownlint-cli
* `npmjs`: the website used for npm

## References

* https://www.npmjs.com/package/@arethetypeswrong/cli
* https://github.com/igorshubovych/markdownlint-cli
* https://npmjs.com

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
