### PR TITLE
fix: add 'boop'

### DIFF
--- a/dictionaries/gaming-terms/src/gaming-terms.txt
+++ b/dictionaries/gaming-terms/src/gaming-terms.txt
@@ -2,6 +2,7 @@
 Aggro
 Aimbot
 Buff
+boop
 Cutscene
 DBNO
 Deathmatch

--- a/dictionaries/software-terms/src/coding-terms.txt
+++ b/dictionaries/software-terms/src/coding-terms.txt
@@ -124,6 +124,7 @@ boilerplate
 boilerplated
 boilerplates
 boilerplating
+boop
 bootloader
 bork
 borked # https://en.wiktionary.org/wiki/borked


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: _coding terms_, _gaming terms_

## Description

Adds "boop". 

## References

From https://en.wiktionary.org/wiki/boop:

> 1. A low-pitched beeping sound.
> (colloquial) 2. A gentle or playful tap or strike, especially on the nose.

1. _"Beep boop"_ is a phrase sometimes used to refer to computer noises
2. _"Boop"_ on its own is also used to refer to _"booping"_ something

Also, Jake from Adventure Time: https://www.youtube.com/watch?v=X6SX50H54Gg

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not im

![Sterling Archer from Archer with a mustache, poking Lana's nose. Caption: 'boop'](https://github.com/user-attachments/assets/690a3c5c-552b-44c1-8fa6-874aed074c7a)

