### PR TITLE
fix: Remove misspelling `equivelent ` from CPP

### DIFF
--- a/dictionaries/cpp/dict/cpp.txt
+++ b/dictionaries/cpp/dict/cpp.txt
@@ -20456,7 +20456,6 @@ equivalence
 equivalent
 equivalently
 equivalents
-equivelent
 eqvparsl
 er
 er_ecnt

--- a/dictionaries/cpp/samples/cpp.txt
+++ b/dictionaries/cpp/samples/cpp.txt
@@ -24763,7 +24763,6 @@ equivalence
 equivalent
 equivalently
 equivalents
-equivelent
 eqvparsl
 er
 er_ecnt

--- a/dictionaries/cpp/src/cpp.txt
+++ b/dictionaries/cpp/src/cpp.txt
@@ -32648,7 +32648,6 @@ Equivalent
 equivalently
 equivalents
 equivDD
-equivelent
 eqvparsl
 EQzB
 er_data

--- a/dictionaries/cpp/src/exclude-terms.txt
+++ b/dictionaries/cpp/src/exclude-terms.txt
@@ -8,4 +8,5 @@ definitons
 defintion
 defintions
 defitions
+equivelent
 redefintions


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: CPP

## Description

Remove misspelling `equivelent ` from CPP

fixes #4225 

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
