### PR TITLE
fix: add `neostandard`

### DIFF
--- a/dictionaries/npm/src/npm.txt
+++ b/dictionaries/npm/src/npm.txt
@@ -2,6 +2,7 @@
 # This should only include NPM packages. Please put other terms in another location.
 # Packages not found at https://npmjs.com will be removed.
 # To add a new packages, just add it after this line, it will get automatically sorted.
+neostandard
 @11ty/eleventy
 @adobe/css-tools
 @adonisjs/core


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: npm

## Description

This is adding [`neostandard`](https://www.npmjs.com/package/neostandard).

## References

https://www.npmjs.com/package/neostandard

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
