### PR TITLE
fix: Ignore BitInt literal hex numbers.

### DIFF
--- a/dictionaries/typescript/cspell-ext.json
+++ b/dictionaries/typescript/cspell-ext.json
@@ -14,6 +14,11 @@
     // Patterns
     "patterns": [
         {
+            "name": "js-hex-number",
+            "pattern": "/\\b0[xX][a-fA-F0-9]+n?\\b/g",
+            "description": "JavaScript Hexadecimal Number including BigInt."
+        },
+        {
             "name": "js-hex-escape",
             "pattern": "/\\\\x[a-f0-9]{2}/gi",
             "description": "JavaScript String Hexadecimal Escape sequence."
@@ -33,7 +38,7 @@
         {
             "languageId": "typescript,javascript,typescriptreact,javascriptreact,mdx,astro",
             "locale": "*",
-            "ignoreRegExpList": ["js-hex-escape", "js-unicode-escape", "js-regexp-flags"],
+            "ignoreRegExpList": ["js-hex-escape", "js-unicode-escape", "js-regexp-flags", "js-hex-number"],
             "dictionaries": ["typescript"]
         },
         {

--- a/dictionaries/typescript/samples/sample.tsx
+++ b/dictionaries/typescript/samples/sample.tsx
@@ -15,3 +15,5 @@ function main() {
 const r0 = /Apples\s\w+/gimusy;
 
 const dir = '/files/guys/';
+
+const bigNum = 0xffn;


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: TypeScript / JavaScript

## Description

Ignore BitInt literal hex numbers.

Fixes #4237 

## References

- [BigInt - JavaScript | MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt)

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
