### PR TITLE
fix: add decompile to software terms

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -400,6 +400,7 @@ declarator
 declarators
 decls
 decodable
+decompile
 dedent
 deduped
 dedupes


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: Software Terms

## Description

Adds a single word to software terms, this word is also defined on Collins (British dictionary)!

## References

- decompile
  - [decompile on Collins, a British Dictionary](https://www.collinsdictionary.com/dictionary/english/decompile)
  - [decompile on Wordnik, an open dictionary](https://www.wordnik.com/words/decompile)
  - [decompiler on Wikipedia](https://en.wikipedia.org/wiki/Decompiler)

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
