### PR TITLE
fix: add fonticons (fontawesome) to companies

### DIFF
--- a/dictionaries/companies/src/companies.txt
+++ b/dictionaries/companies/src/companies.txt
@@ -698,6 +698,7 @@ Fluor Corporation
 FMC Corporation
 FMC Technologies, Inc.
 Foncire Euris
+Fonticons, Inc.
 Foot Locker, Inc.
 Ford Motor
 Ford Motor Company


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: companies

## Description

Adds `Fonticons, Inc.`, the company behind Font Awesome.

## References

> Fonticons, Inc., a Delaware corporation (the Company)…
> 
> — https://fontawesome.com/license

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.

## Related

* https://github.com/svg/svgo/pull/2101