### PR TITLE
fix: add bézier to dictionary

### DIFF
--- a/dictionaries/en_shared/src/shared-additional-words.txt
+++ b/dictionaries/en_shared/src/shared-additional-words.txt
@@ -12,6 +12,7 @@ Arubans
 attaboys
 audiobook
 audiobooks
+Bézier
 bicep
 Bonanno
 breathwork


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: shared-additional-words

## Description

Adds the word "Bézier" with the the diacritic. Merriam-Webster, an American English dictionary has an entry for this, but British Dictionaries don't seem to.

On Wikipedia, it is always referred to with the diacritic as well, despite the dictionary suggesting it's less common to do so.

## References

- https://en.wikipedia.org/wiki/B%C3%A9zier_curve
- https://www.merriam-webster.com/dictionary/Bezier — See variants

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.

## Related

* https://github.com/svg/svgo/pull/2101