### PR TITLE
feat: Ignore Forbidden Words

### DIFF
--- a/dictionaries/ca/cspell-ext.json
+++ b/dictionaries/ca/cspell-ext.json
@@ -9,7 +9,8 @@
         {
             "name": "ca",
             "path": "./ca.trie.gz",
-            "description": "Catalan dictionary."
+            "description": "Catalan dictionary.",
+            "ignoreForbiddenWords": true
         }
     ],
     // Dictionaries to always be used.

--- a/dictionaries/da_DK/cspell-ext.json
+++ b/dictionaries/da_DK/cspell-ext.json
@@ -9,6 +9,7 @@
             "name": "da-dk",
             "path": "./da_DK.trie",
             "description": "Danish (da-DK) Dictionary.",
+            "ignoreForbiddenWords": true,
             "repMap": [
                 ["aa", "å"],
                 ["Aa", "Å"]

--- a/dictionaries/de_AT/cspell-ext.json
+++ b/dictionaries/de_AT/cspell-ext.json
@@ -9,6 +9,7 @@
             "name": "de-at",
             "path": "./de_AT.trie.gz",
             "description": "Austrian German (de-AT) Dictionary.",
+            "ignoreForbiddenWords": true,
             "repMap": [
                 ["ae", "ä"],
                 ["oe", "ö"],

--- a/dictionaries/de_CH/cspell-ext.json
+++ b/dictionaries/de_CH/cspell-ext.json
@@ -9,6 +9,7 @@
             "name": "de-ch",
             "path": "./de_CH.trie.gz",
             "description": "Swiss German (de-CH) Dictionary.",
+            "ignoreForbiddenWords": true,
             "repMap": [
                 ["ae", "ä"],
                 ["oe", "ö"],

--- a/dictionaries/de_DE/cspell-ext.json
+++ b/dictionaries/de_DE/cspell-ext.json
@@ -9,6 +9,7 @@
             "name": "de-de",
             "path": "./de_DE.trie.gz",
             "description": "German (de-DE) Dictionary.",
+            "ignoreForbiddenWords": true,
             "repMap": [
                 ["ae", "ä"],
                 ["oe", "ö"],

--- a/dictionaries/fr_FR/cspell-ext.json
+++ b/dictionaries/fr_FR/cspell-ext.json
@@ -7,6 +7,7 @@
             "name": "fr-fr",
             "path": "./fr-fr.trie.gz",
             "description": "French Dictionary (France)",
+            "ignoreForbiddenWords": true,
             "repMap": [
                 ["'", "’"],
                 ["ﬃ", "ffi"],

--- a/dictionaries/fr_FR_90/cspell-ext.json
+++ b/dictionaries/fr_FR_90/cspell-ext.json
@@ -9,6 +9,7 @@
             "name": "fr-fr-90",
             "path": "./fr-reforme1990.trie.gz",
             "description": "Français Réforme 1990 dictionary.",
+            "ignoreForbiddenWords": true,
             "repMap": [
                 ["'", "’"],
                 ["ﬃ", "ffi"],

--- a/dictionaries/hr_HR/cspell-ext.json
+++ b/dictionaries/hr_HR/cspell-ext.json
@@ -9,7 +9,8 @@
         {
             "name": "hr-hr",
             "path": "./dict/hr_HR.trie.gz",
-            "description": "Croatian dictionary."
+            "description": "Croatian dictionary.",
+            "ignoreForbiddenWords": true
         }
     ],
     // Dictionaries to always be used.

--- a/dictionaries/hu_HU/cspell-ext.json
+++ b/dictionaries/hu_HU/cspell-ext.json
@@ -10,7 +10,8 @@
         {
             "name": "hu-hu",
             "path": "./dict/hu-hu.trie.gz",
-            "description": "Hungarian dictionary."
+            "description": "Hungarian dictionary.",
+            "ignoreForbiddenWords": true
         }
     ],
     // Dictionaries to always be used.

--- a/dictionaries/la/cspell-ext.json
+++ b/dictionaries/la/cspell-ext.json
@@ -10,7 +10,8 @@
         {
             "name": "la",
             "path": "./la.trie.gz",
-            "description": "Latin dictionary."
+            "description": "Latin dictionary.",
+            "ignoreForbiddenWords": true
         }
     ],
     // Dictionaries to always be used.

--- a/dictionaries/mn_MN/cspell-ext.json
+++ b/dictionaries/mn_MN/cspell-ext.json
@@ -8,7 +8,8 @@
         {
             "name": "mn-mn",
             "path": "./dict/mn-mn.trie.gz",
-            "description": "Mongolian dictionary."
+            "description": "Mongolian dictionary.",
+            "ignoreForbiddenWords": true
         }
     ],
     "languageSettings": [

--- a/dictionaries/nl_NL/cspell-ext.json
+++ b/dictionaries/nl_NL/cspell-ext.json
@@ -9,6 +9,7 @@
             "name": "nl-nl",
             "path": "./Dutch.trie.gz",
             "description": "Dutch (Netherlands) Dictionary",
+            "ignoreForbiddenWords": true,
             "dictionaryInformation": {
                 "locale": "nl-NL",
                 "alphabet": "a-zA-Zëqïéèöêüçàûîñäô",

--- a/dictionaries/pt_BR/cspell-ext.json
+++ b/dictionaries/pt_BR/cspell-ext.json
@@ -8,7 +8,8 @@
         {
             "name": "pt-br",
             "path": "./pt_BR.trie.gz",
-            "description": "Portuguese (Brazilian) Dictionary"
+            "description": "Portuguese (Brazilian) Dictionary",
+            "ignoreForbiddenWords": true
         }
     ],
     "dictionaries": [],

--- a/dictionaries/ru_RU/cspell-ext.json
+++ b/dictionaries/ru_RU/cspell-ext.json
@@ -10,7 +10,8 @@
         {
             "name": "ru-ru",
             "path": "./ru_ru.trie.gz",
-            "description": "Russian Dictionary (Combined)"
+            "description": "Russian Dictionary (Combined)",
+            "ignoreForbiddenWords": true
         }
     ],
     // Dictionaries to always be used.

--- a/dictionaries/sv/cspell-ext.json
+++ b/dictionaries/sv/cspell-ext.json
@@ -10,7 +10,8 @@
         {
             "name": "sv",
             "path": "./Swedish.trie.gz",
-            "description": "Swedish Dictionary"
+            "description": "Swedish Dictionary",
+            "ignoreForbiddenWords": true
         }
     ],
     // Dictionaries to always be used.


### PR DESCRIPTION
## Description

Forbidden words in language dictionaries can cause problems when combined with other dictionaries.

For not, just treat forbidden words as not found in the dictionary.

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
