### PR TITLE
fix: add 'tsdown'

### DIFF
--- a/dictionaries/npm/dict/npm.txt
+++ b/dictionaries/npm/dict/npm.txt
@@ -2480,6 +2480,7 @@ tsd
 tsd-lite
 tsdoc
 tsdoc-config
+tsdown
 tseslint
 tshy
 tslib

--- a/dictionaries/npm/src/npm.txt
+++ b/dictionaries/npm/src/npm.txt
@@ -2497,6 +2497,7 @@ ts-rule-engine
 tsconfig-paths
 tsd
 tsd-lite
+tsdown
 tseslint
 tshy
 tslib


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: _npm_

## Description

Adds "tsdown"

## References

- https://github.com/rolldown/tsdown

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
