### PR TITLE
fix: add demosaic to software-terms

### DIFF
--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -2212,3 +2212,7 @@ zip
 zlib
 ZPool
 ZPools
+demosaic
+demosaics
+demosaiced
+demosaicing


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: software-terms.txt

## Description

Added `demosaic` and its different forms to software-terms.
This word is used in digital image processing.

## References

- https://en.wikipedia.org/wiki/Demosaicing
  - demosaic
  - demosaiced
  - demosaicing
- demosaics
  - https://en.wiktionary.org/wiki/demosaics
  - https://arxiv.org/abs/2211.13732

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
