### PR TITLE
fix: Make sure `en_GB-MIT` is a drop in replacement for `en_GB`.

### DIFF
--- a/dictionaries/en_GB-MIT/cspell-ext.json
+++ b/dictionaries/en_GB-MIT/cspell-ext.json
@@ -7,7 +7,7 @@
     // List of dictionary files to add to the global list of dictionaries
     "dictionaryDefinitions": [
         {
-            "name": "en-gb-mit",
+            "name": "en-gb",
             "path": "./en_GB.trie.gz",
             "repMap": [["'|`|’", "'"]],
             "description": "British English Dictionary"
@@ -38,7 +38,7 @@
                 }
             ],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
-            "dictionaries": ["en-gb-mit"],
+            "dictionaries": ["en-gb"],
             // Dictionary definitions can also be supplied here
             "dictionaryDefinitions": []
         }

--- a/dictionaries/en_GB-MIT/cspell-tools.config.yaml
+++ b/dictionaries/en_GB-MIT/cspell-tools.config.yaml
@@ -104,3 +104,4 @@ targets:
       - ./node_modules/@cspell/dict-en-shared/dict/exclude-words.txt
 
 checksumFile: true
+# cspell:words Marco Pinto


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _en_GB-MIT_

## Description

Make sure the `en-gb-mit` dictionary is a drop in replacement for the LGPL `en-gb` dictionary.

By reusing the dictionary name, it allows for replacement.

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
