### PR TITLE
refactor: consolidate English shared `-ise` words into `shared-additional-words-ise.txt`

### DIFF
--- a/dictionaries/aoo-mozilla-en-dict/README.md
+++ b/dictionaries/aoo-mozilla-en-dict/README.md
@@ -7,3 +7,9 @@ It can happen that a dictionary source "goes away" preventing us from building t
 This "package" exits as a centralized point for aoo-mozilla-en-dict dictionary dependencies.
 
 We also try to avoid including binary files.
+
+> [!WARNING]
+> - The words in this folder are not indented to be maintained manually via PR.
+> - PRs about adding or fixing words would be rejected.
+> - If you want to contribute to this source, please consider opening an issue on original source.
+> - If you want to update aoo-mozilla-en-dict from its source, PRs are welcomed

--- a/dictionaries/en_AU/README.md
+++ b/dictionaries/en_AU/README.md
@@ -48,7 +48,7 @@ npm run build
 
 ## Adding Words
 
-Please add any words to [src/additional_words.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_AU/src/additional_words.txt) by making a pull request.
+Contributions are welcomed and encouraged, please read [src/README.md](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_AU/src/README.md).
 
 ## License
 

--- a/dictionaries/en_AU/cspell-tools.config.yaml
+++ b/dictionaries/en_AU/cspell-tools.config.yaml
@@ -8,6 +8,7 @@ targets:
       - ./node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_AU (Kevin Atkinson)/en_AU.dic
       - ./node_modules/@cspell/dict-en-shared/dict/acronyms.txt
       - ./node_modules/@cspell/dict-en-shared/dict/shared-additional-words.txt
+      - ./node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ise.txt
     format: trie3
     targetDirectory: '.'
     generateNonStrict: true

--- a/dictionaries/en_AU/src/README.md
+++ b/dictionaries/en_AU/src/README.md
@@ -1,3 +1,13 @@
 # Source Directory
 
-All source files used to generate the dictionary should be stored in this directory.
+All source files used to generate the `en_AU` dictionary should be stored in this directory.
+
+> [!WARNING]
+> The files in this folder are only about Australian English
+
+> [!NOTE]
+add any words to [`additional_words.txt`](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_AU/src/additional_words.txt) by making a pull request.
+
+> [!WARNING]
+> If the words you want to add is valid for more than one English flavors (en_US, en_AU, en_CA, en_GB, ...), please contribute to
+> [`en_shared`](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_shared/src/) dictionary.

--- a/dictionaries/en_AU/src/hunspell-en_AU-large/README.md
+++ b/dictionaries/en_AU/src/hunspell-en_AU-large/README.md
@@ -1,0 +1,16 @@
+# hunspell source
+
+The words in this folder are included in the CSpell `en_AU` dictionary.
+
+> [!CAUTION]
+> These words comes from [hunspell](https://github.com/hunspell/hunspell) `en_AU` dictionary.
+
+> [!WARNING]
+> - The words in this folder are not indented to be maintained manually via PR.
+> - PRs about adding or fixing words would be rejected.
+> - If you want to contribute to this source, please consider opening an issue on original source.
+> - If you want to update hunspell from its source, PRs are welcomed
+
+> [!NOTE]
+> - If you want to simply add words to the dictionary, but not the `hunspell` source, you can follow
+> [these instructions](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_CA/src/README.md).

--- a/dictionaries/en_CA/README.md
+++ b/dictionaries/en_CA/README.md
@@ -48,7 +48,8 @@ npm run build
 
 ## Adding Words
 
-Please add any words to [src/additional_words.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_CA/src/additional_words.txt) by making a pull request.
+Contributions are welcomed and encouraged, please read [src/README.md](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_CA/src/README.md).
+
 
 ## License
 

--- a/dictionaries/en_CA/cspell-tools.config.yaml
+++ b/dictionaries/en_CA/cspell-tools.config.yaml
@@ -8,6 +8,7 @@ targets:
       - node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_CA (Kevin Atkinson)/en_CA.dic
       - node_modules/@cspell/dict-en-shared/dict/acronyms.txt
       - node_modules/@cspell/dict-en-shared/dict/shared-additional-words.txt
+      - node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ise.txt
     format: trie3
     targetDirectory: '.'
     generateNonStrict: true

--- a/dictionaries/en_CA/src/README.md
+++ b/dictionaries/en_CA/src/README.md
@@ -1,3 +1,15 @@
 # Source Directory
 
-All source files used to generate the dictionary should be stored in this directory.
+All source files used to generate the `en_CA` dictionary should be stored in this directory.
+
+> [!WARNING]
+> The files in this folder are only about Canadian English.
+
+## Adding words
+
+> [!NOTE]:
+> add any words to [`additional_words.txt`](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_CA/src/additional_words.txt) by making a pull request.
+
+> [!WARNING]
+> If the words you want to add is valid for more than one English flavors (en_US, en_AU, en_CA, en_GB, ...), please contribute to
+> [`en_shared`](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_shared/src/) dictionary.

--- a/dictionaries/en_CA/src/hunspell-en_CA-large/README.md
+++ b/dictionaries/en_CA/src/hunspell-en_CA-large/README.md
@@ -1,0 +1,16 @@
+# hunspell source
+
+The words in this folder are included in the CSpell `en_CA` dictionary.
+
+> [!CAUTION]
+> These words comes from [hunspell](https://github.com/hunspell/hunspell) `en_CA` dictionary.
+
+> [!WARNING]
+> - The words in this folder are not indented to be maintained manually via PR.
+> - PRs about adding or fixing words would be rejected.
+> - If you want to contribute to this source, please consider opening an issue on original source.
+> - If you want to update hunspell from its source, PRs are welcomed
+
+> [!NOTE]
+> - If you want to simply add words to the dictionary, but not the `hunspell` source, you can follow
+> [these instructions](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_CA/src/README.md).

--- a/dictionaries/en_GB-MIT/README.md
+++ b/dictionaries/en_GB-MIT/README.md
@@ -43,7 +43,7 @@ npm run build
 
 ## Adding Words
 
-Please add any words to [src/additional_words.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_GB-MIT/src/additional_words.txt) by making a pull request.
+Contributions are welcomed and encouraged, please read [src/README.md](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_GB-MIT/src/README.md).
 
 ## License
 

--- a/dictionaries/en_GB-MIT/cspell-tools.config.yaml
+++ b/dictionaries/en_GB-MIT/cspell-tools.config.yaml
@@ -10,6 +10,7 @@ targets:
       - ../en_GB/src/additional_words.txt
       - ./node_modules/@cspell/dict-en-shared/dict/acronyms.txt
       - ./node_modules/@cspell/dict-en-shared/dict/shared-additional-words.txt
+      - ./node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ise.txt
       - ./src/acronyms.txt
       - ./src/additional_words.txt
       - ./src/legacy/wordsEnGb.txt
@@ -94,6 +95,7 @@ targets:
       - ../en_GB/src/additional_words.txt
       - ./node_modules/@cspell/dict-en-shared/dict/acronyms.txt
       - ./node_modules/@cspell/dict-en-shared/dict/shared-additional-words.txt
+      - ./node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ise.txt
       - ./src/acronyms.txt
       - ./src/additional_words.txt
       - ./src/generated/en-gb-generated.txt

--- a/dictionaries/en_GB-MIT/src/README.md
+++ b/dictionaries/en_GB-MIT/src/README.md
@@ -1,3 +1,13 @@
 # Source Directory
 
-All source files used to generate the dictionary should be stored in this directory.
+All source files used to generate the `en_GB-MIT` dictionary should be stored in this directory.
+
+> [!WARNING]
+> The files in this folder are only about British English
+
+> [!NOTE]
+add any words to [`additional_words.txt`](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_GB-MIT/src/additional_words.txt) by making a pull request.
+
+> [!WARNING]
+> If the words you want to add is valid for more than one English flavors (en_US, en_AU, en_CA, en_GB, ...), please contribute to
+> [`en_shared`](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_shared/src/) dictionary.

--- a/dictionaries/en_GB-ise/README.md
+++ b/dictionaries/en_GB-ise/README.md
@@ -40,7 +40,7 @@ The `cspell-ext.json` file in this package should be added to the import section
 
 ## Adding Words
 
-Please add any words to [src/additional_words.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_GB-ise/src/additional_words.txt) by making a pull request.
+Contributions are welcomed and encouraged, please read [src/README.md](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_GB-ise/src/README.md).
 
 ## License
 

--- a/dictionaries/en_GB-ise/cspell-tools.config.yaml
+++ b/dictionaries/en_GB-ise/cspell-tools.config.yaml
@@ -10,6 +10,7 @@ targets:
       - node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_GB (Marco Pinto) (-ise) (2025+)/en_GB.dic
       - node_modules/@cspell/dict-en-shared/dict/acronyms.txt
       - node_modules/@cspell/dict-en-shared/dict/shared-additional-words.txt
+      - node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ise.txt
     sort: true
     generateNonStrict: true
     excludeWordsFrom:

--- a/dictionaries/en_GB-ise/src/README.md
+++ b/dictionaries/en_GB-ise/src/README.md
@@ -1,3 +1,20 @@
 # Source Directory
 
-All source files used to generate the dictionary should be stored in this directory.
+All source files used to generate the `en_GB-ise` dictionary should be stored in this directory.
+
+## License
+
+The contributions in this folder are considered as being MIT even if the `en_GB-ise` package is published with `LGPL`,
+because it uses `LGPL` tainted sources.
+
+## Adding words
+
+> [!WARNING]
+> The files in this folder are only about British English.
+
+> [!NOTE]:
+> add any words to [`additional_words.txt`](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_GB-ise/src/additional_words.txt) by making a pull request.
+
+> [!WARNING]
+> If the words you want to add is valid for more than one English flavors (en_US, en_AU, en_CA, en_GB, ...), please contribute to
+> [`en_shared`](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_shared/src/) dictionary.

--- a/dictionaries/en_GB-legacy/cspell-tools.config.yaml
+++ b/dictionaries/en_GB-legacy/cspell-tools.config.yaml
@@ -14,6 +14,7 @@ targets:
     excludeWordsFrom:
       - node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_GB (Marco Pinto) (-ise -ize) (2025+)/en_GB.dic
       - node_modules/@cspell/dict-en-shared/dict/shared-additional-words.txt
+      - node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ise.txt
       - node_modules/@cspell/dict-en-shared/dict/acronyms.txt
       - node_modules/@cspell/dict-en-shared/dict/exclude-words.txt
       - ../en_GB/src/additional_words.txt

--- a/dictionaries/en_GB-legacy/src/README.md
+++ b/dictionaries/en_GB-legacy/src/README.md
@@ -1,3 +1,15 @@
 # Source Directory
 
-All source files used to generate the dictionary should be stored in this directory.
+All source files used to generate the `en_GB-legacy` dictionary should be stored in this directory.
+
+## Adding words
+
+> [!WARNING]
+> This dictionary includes words that had been included in older versions of the [`en_GB`](https://github.com/streetsidesoftware/cspell-dicts/tree/main/dictionaries/en_GB) dictionary.
+> They have been moved here to make the [`en_GB`](https://github.com/streetsidesoftware/cspell-dicts/tree/main/dictionaries/en_GB) dictionary easier to maintain.
+>
+> These files are not intended to be maintained by opensource contributions
+
+> [!NOTE]
+> Please consider adding words to [`en_GB`](https://github.com/streetsidesoftware/cspell-dicts/tree/main/dictionaries/en_GB/src) dictionary.
+

--- a/dictionaries/en_GB/README.md
+++ b/dictionaries/en_GB/README.md
@@ -40,7 +40,7 @@ The `cspell-ext.json` file in this package should be added to the import section
 
 ## Adding Words
 
-Please add any words to [src/additional_words.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_GB/src/additional_words.txt) by making a pull request.
+Contributions are welcomed and encouraged, please read [src/README.md](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_GB/src/README.md).
 
 ## License
 

--- a/dictionaries/en_GB/cspell-tools.config.yaml
+++ b/dictionaries/en_GB/cspell-tools.config.yaml
@@ -10,6 +10,7 @@ targets:
       - node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_GB (Marco Pinto) (-ise -ize) (2025+)/en_GB.dic
       - node_modules/@cspell/dict-en-shared/dict/acronyms.txt
       - node_modules/@cspell/dict-en-shared/dict/shared-additional-words.txt
+      - node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ise.txt
     sort: true
     generateNonStrict: true
     excludeWordsFrom:

--- a/dictionaries/en_GB/src/README.md
+++ b/dictionaries/en_GB/src/README.md
@@ -1,3 +1,12 @@
 # Source Directory
 
-All source files used to generate the dictionary should be stored in this directory.
+All source files used to generate the `en_GB` dictionary should be stored in this directory.
+
+## Adding words
+
+> [!NOTE]:
+> add any words to [`additional_words.txt`](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_GB/src/additional_words.txt) by making a pull request.
+
+> [!WARNING]
+> If the words you want to add is valid for more than one English flavors (en_US, en_AU, en_CA, en_GB, ...), please contribute to
+> [`en_shared`](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_shared/src/) dictionary.

--- a/dictionaries/en_US/README.md
+++ b/dictionaries/en_US/README.md
@@ -52,7 +52,7 @@ npm run build
 
 ## Adding Words
 
-Please add any words to [src/additional_words.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_US/src/additional_words.txt) by making a pull request.
+Contributions are welcomed and encouraged, please read [src/README.md](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_US/src/README.md).
 
 ## Resources
 

--- a/dictionaries/en_US/src/README.md
+++ b/dictionaries/en_US/src/README.md
@@ -1,3 +1,15 @@
 # Source Directory
 
-All source files used to generate the dictionary should be stored in this directory.
+All source files used to generate the `en_US` dictionary should be stored in this directory.
+
+## Adding words
+
+> [!WARNING]
+> The files in this folder are only about American English.
+
+> [!NOTE]:
+> add any words to [`additional_words.txt`](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_US/src/additional_words.txt) by making a pull request.
+
+> [!WARNING]
+> If the words you want to add is valid for more than one English flavors (en_US, en_AU, en_CA, en_GB, ...), please contribute to
+> [`en_shared`](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_shared/src/) dictionary.

--- a/dictionaries/en_US/src/hunspell/README.md
+++ b/dictionaries/en_US/src/hunspell/README.md
@@ -1,0 +1,16 @@
+# hunspell source
+
+The words in this folder are included in the CSpell `en_US` dictionary.
+
+> [!CAUTION]
+> These words comes from [hunspell](https://github.com/hunspell/hunspell) `en_US` dictionary.
+
+> [!WARNING]
+> - The words in this folder are not indented to be maintained manually via PR.
+> - PRs about adding or fixing words would be rejected.
+> - If you want to contribute to this source, please consider opening an issue on original source.
+> - If you want to update hunspell from its source, PRs are welcomed
+
+> [!NOTE]
+> - If you want to simply add words to the dictionary, but not the `hunspell` source, you can follow
+> [these instructions](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_US/src/README.md).

--- a/dictionaries/en_US/src/legacy/README.md
+++ b/dictionaries/en_US/src/legacy/README.md
@@ -1,0 +1,11 @@
+# legacy en_US
+
+The files in this folder comes from old ages of CSpell.
+
+> [!WARNING]
+> - The words in this folder are not indented to be maintained.
+> - PRs about adding or fixing words would be rejected.
+
+> [!NOTE]
+> - If you want to simply add words to the dictionary, but not the `legacy` source, you can follow
+> [these instructions](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_US/src/README.md).

--- a/dictionaries/en_shared/cspell-tools.config.yaml
+++ b/dictionaries/en_shared/cspell-tools.config.yaml
@@ -11,6 +11,16 @@ targets:
     compress: false
     excludeWordsFrom:
       - src/exclude-words.txt
+  - name: 'shared-additional-words-ise'
+    sources:
+      - filename: src/shared-additional-words-ise.txt
+        split: true
+    format: plaintext
+    targetDirectory: './dict'
+    generateNonStrict: false
+    compress: false
+    excludeWordsFrom:
+      - src/exclude-words.txt
   - name: exclude-words
     sources:
       - filename: src/exclude-words.txt

--- a/dictionaries/en_shared/src/README.md
+++ b/dictionaries/en_shared/src/README.md
@@ -1,3 +1,9 @@
 # Source Directory
 
-All source files used to generate the dictionary should be stored in this directory.
+All source files used to generate the English dictionaries should be stored in this directory.
+
+## Adding words
+
+If the words you want to add is valid for:
+- all English flavors (en_US, en_AU, en_CA, en_GB, ...),
+add them to [shared-additional-words.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_shared/src/shared-additional-words.txt)

--- a/dictionaries/en_shared/src/README.md
+++ b/dictionaries/en_shared/src/README.md
@@ -7,3 +7,5 @@ All source files used to generate the English dictionaries should be stored in t
 If the words you want to add is valid for:
 - all English flavors (en_US, en_AU, en_CA, en_GB, ...),
 add them to [shared-additional-words.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_shared/src/shared-additional-words.txt)
+- all non-American English flavors (en_AU, en_CA, en_GB, ...),
+add them to [shared-additional-words-ise.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_shared/src/shared-additional-words-ise.txt)

--- a/dictionaries/en_shared/src/shared-additional-words-ise.txt
+++ b/dictionaries/en_shared/src/shared-additional-words-ise.txt
@@ -1,0 +1,10 @@
+# These are shared words for all variants of English that uses the -ise suffix.
+# So mostly all English flavors except American English
+
+computerised
+parameterise
+serialisation
+synchronisation
+synchronise
+unmanoeuvrable
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,6 +444,8 @@ importers:
 
   dictionaries/fr_FR_90: {}
 
+  dictionaries/fr_FR_shared: {}
+
   dictionaries/fsharp: {}
 
   dictionaries/fullstack: {}


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _all English dictionary`

## Description

- **chore: add instructions for external dictionaries source**
- **chore: add maintenance instructions for English dictionaries**
- **chore: add instructions for en_GB and en_GB-legacy**
- **chore: update contributions instructions in README files**
- **feat: add a shared-additional-words-ise.txt to en_shared**

## References

- https://github.com/streetsidesoftware/cspell-dicts/pull/4391#discussion_r2072976066

## Checklist

- [X] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [X] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
