### PR TITLE
Draft: work on licenses for en_GB dictionaries - option 1

### DIFF
--- a/dictionaries/en_AU/README.md
+++ b/dictionaries/en_AU/README.md
@@ -52,6 +52,10 @@ Contributions are welcomed and encouraged, please read [src/README.md](https://g
 
 ## License
 
+The code used to build this dictionary is licensed under `MIT` license.
+
+But because of the sources it includes, the `@cspell/dict-en-au` package is released under:
+
 LGPL-3.0-or-later
 
 > Some packages may have other licenses included.

--- a/dictionaries/en_AU/README.md
+++ b/dictionaries/en_AU/README.md
@@ -52,7 +52,7 @@ Contributions are welcomed and encouraged, please read [src/README.md](https://g
 
 ## License
 
-GPL-3.0-or-later
+LGPL-3.0-or-later
 
 > Some packages may have other licenses included.
 

--- a/dictionaries/en_CA/README.md
+++ b/dictionaries/en_CA/README.md
@@ -52,7 +52,7 @@ Contributions are welcomed and encouraged, please read [src/README.md](https://g
 
 ## License
 
-GPL-3.0-or-later
+LGPL-3.0-or-later
 
 > Some packages may have other licenses included.
 

--- a/dictionaries/en_CA/README.md
+++ b/dictionaries/en_CA/README.md
@@ -52,6 +52,10 @@ Contributions are welcomed and encouraged, please read [src/README.md](https://g
 
 ## License
 
+The code used to build this dictionary is licensed under `MIT` license.
+
+But because of the sources it includes, the `@cspell/dict-en-ca` package is released under:
+
 LGPL-3.0-or-later
 
 > Some packages may have other licenses included.

--- a/dictionaries/en_GB-ise/README.md
+++ b/dictionaries/en_GB-ise/README.md
@@ -44,6 +44,10 @@ Contributions are welcomed and encouraged, please read [src/README.md](https://g
 
 ## License
 
+The code used to build this dictionary is licensed under `MIT` license.
+
+But because of the sources it includes, the `@cspell/dict-en-gb-ise` package is released under:
+
 LGPL-3.0-or-later
 
 > Some packages may have other licenses included.

--- a/dictionaries/en_GB/README.md
+++ b/dictionaries/en_GB/README.md
@@ -44,7 +44,7 @@ Contributions are welcomed and encouraged, please read [src/README.md](https://g
 
 ## License
 
-GPL-3.0-or-later
+LGPL-3.0-or-later
 
 > Some packages may have other licenses included.
 

--- a/dictionaries/en_GB/README.md
+++ b/dictionaries/en_GB/README.md
@@ -44,6 +44,10 @@ Contributions are welcomed and encouraged, please read [src/README.md](https://g
 
 ## License
 
+The code used to build this dictionary is licensed under `MIT` license.
+
+But because of the sources it includes, the `@cspell/dict-en-gb` package is released under:
+
 LGPL-3.0-or-later
 
 > Some packages may have other licenses included.


### PR DESCRIPTION
- **fix: error in license for en_AU, en_CA & en_GB dictionaries**
- **chore: add more information to license in README files**
