### PR TITLE
 Draft: work on licenses for en_GB dictionaries - option 3

### DIFF
--- a/dictionaries/en_AU/README.md
+++ b/dictionaries/en_AU/README.md
@@ -52,7 +52,7 @@ Contributions are welcomed and encouraged, please read [src/README.md](https://g
 
 ## License
 
-GPL-3.0-or-later
+LGPL-3.0-or-later
 
 > Some packages may have other licenses included.
 

--- a/dictionaries/en_AU/src/LICENSE
+++ b/dictionaries/en_AU/src/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2020 Jason Dent <jason@streetsidesoftware.nl>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dictionaries/en_CA/README.md
+++ b/dictionaries/en_CA/README.md
@@ -52,7 +52,7 @@ Contributions are welcomed and encouraged, please read [src/README.md](https://g
 
 ## License
 
-GPL-3.0-or-later
+LGPL-3.0-or-later
 
 > Some packages may have other licenses included.
 

--- a/dictionaries/en_CA/src/LICENSE
+++ b/dictionaries/en_CA/src/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2020 Jason Dent <jason@streetsidesoftware.nl>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dictionaries/en_GB-ise/src/LICENSE
+++ b/dictionaries/en_GB-ise/src/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2020 Jason Dent <jason@streetsidesoftware.nl>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dictionaries/en_GB/README.md
+++ b/dictionaries/en_GB/README.md
@@ -44,7 +44,7 @@ Contributions are welcomed and encouraged, please read [src/README.md](https://g
 
 ## License
 
-GPL-3.0-or-later
+LGPL-3.0-or-later
 
 > Some packages may have other licenses included.
 

--- a/dictionaries/en_GB/src/LICENSE
+++ b/dictionaries/en_GB/src/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2020 Jason Dent <jason@streetsidesoftware.nl>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
- **fix: error in license for en_AU, en_CA & en_GB dictionaries**
- **chore: add a LICENSE file to some src directories**
