### PR TITLE
chore: Adjust in license referenced in README to match LICENSE file in en_AU, en_CA & en_GB

### DIFF
--- a/dictionaries/en_AU/README.md
+++ b/dictionaries/en_AU/README.md
@@ -52,6 +52,10 @@ Contributions are welcomed and encouraged, please read [src/README.md](https://g
 
 ## License
 
+The code used to build this dictionary is licensed under `MIT` license.
+
+But because of the sources it includes, the `@cspell/dict-en-au` package is released under:
+
 LGPL-3.0-or-later
 
 > Some packages may have other licenses included.

--- a/dictionaries/en_AU/README.md
+++ b/dictionaries/en_AU/README.md
@@ -52,7 +52,7 @@ Contributions are welcomed and encouraged, please read [src/README.md](https://g
 
 ## License
 
-GPL-3.0-or-later
+LGPL-3.0-or-later
 
 > Some packages may have other licenses included.
 

--- a/dictionaries/en_AU/src/LICENSE
+++ b/dictionaries/en_AU/src/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2020 Jason Dent <jason@streetsidesoftware.nl>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dictionaries/en_CA/README.md
+++ b/dictionaries/en_CA/README.md
@@ -52,7 +52,7 @@ Contributions are welcomed and encouraged, please read [src/README.md](https://g
 
 ## License
 
-GPL-3.0-or-later
+LGPL-3.0-or-later
 
 > Some packages may have other licenses included.
 

--- a/dictionaries/en_CA/README.md
+++ b/dictionaries/en_CA/README.md
@@ -52,6 +52,10 @@ Contributions are welcomed and encouraged, please read [src/README.md](https://g
 
 ## License
 
+The code used to build this dictionary is licensed under `MIT` license.
+
+But because of the sources it includes, the `@cspell/dict-en-ca` package is released under:
+
 LGPL-3.0-or-later
 
 > Some packages may have other licenses included.

--- a/dictionaries/en_CA/src/LICENSE
+++ b/dictionaries/en_CA/src/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2020 Jason Dent <jason@streetsidesoftware.nl>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dictionaries/en_GB-ise/README.md
+++ b/dictionaries/en_GB-ise/README.md
@@ -44,6 +44,10 @@ Contributions are welcomed and encouraged, please read [src/README.md](https://g
 
 ## License
 
+The code used to build this dictionary is licensed under `MIT` license.
+
+But because of the sources it includes, the `@cspell/dict-en-gb-ise` package is released under:
+
 LGPL-3.0-or-later
 
 > Some packages may have other licenses included.

--- a/dictionaries/en_GB-ise/src/LICENSE
+++ b/dictionaries/en_GB-ise/src/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2020 Jason Dent <jason@streetsidesoftware.nl>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dictionaries/en_GB/README.md
+++ b/dictionaries/en_GB/README.md
@@ -44,7 +44,7 @@ Contributions are welcomed and encouraged, please read [src/README.md](https://g
 
 ## License
 
-GPL-3.0-or-later
+LGPL-3.0-or-later
 
 > Some packages may have other licenses included.
 

--- a/dictionaries/en_GB/README.md
+++ b/dictionaries/en_GB/README.md
@@ -44,6 +44,10 @@ Contributions are welcomed and encouraged, please read [src/README.md](https://g
 
 ## License
 
+The code used to build this dictionary is licensed under `MIT` license.
+
+But because of the sources it includes, the `@cspell/dict-en-gb` package is released under:
+
 LGPL-3.0-or-later
 
 > Some packages may have other licenses included.

--- a/dictionaries/en_GB/src/LICENSE
+++ b/dictionaries/en_GB/src/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2020 Jason Dent <jason@streetsidesoftware.nl>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION


<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _dictionary_

## Description

- **fix: error in license for en_AU, en_CA & en_GB dictionaries**

The packages were provided under LGPL-3, not GPL3

- **chore: add a LICENSE file to some src directories**

We should make it clear that contributions to these dictionaries are under MIT license

- **chore: add more information to license in README files**

Explain the differences between the way the dictionaries are packaged and the license for the files in the repository.

## References

Closes #4408
Closes #4409 
Closes #4410 

- #4408
- #4409 
- #4410

## Checklist

- [X] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [X] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
