### PR TITLE
fix: some typos in English dictionaries

### DIFF
--- a/dictionaries/en-common-misspellings/dict-en.yaml
+++ b/dictionaries/en-common-misspellings/dict-en.yaml
@@ -4195,3 +4195,5 @@ dictionaryDefinitions:
       - ytou->you
       - yuo->you
       - zeebra->zebra
+      - cohabitating->cohabiting
+      - enterprize->enterprise

--- a/dictionaries/en_US/src/legacy/en_US.txt
+++ b/dictionaries/en_US/src/legacy/en_US.txt
@@ -6246,7 +6246,6 @@ entendres
 enterable
 enterer
 enterers
-enterprize
 enthrallingly
 enthrallments
 enticers

--- a/dictionaries/en_shared/src/exclude-words.txt
+++ b/dictionaries/en_shared/src/exclude-words.txt
@@ -1,7 +1,7 @@
-~colum
-colum
-knifes
-midwifes
+~colum       # Colum is a first name, but not a word
+colum        # Colum is a first name, but not a word
+knifes       # present in hunspell dictionaries with wrong affixes
+midwifes     # present in hunspell dictionaries with wrong affixes
 unwieldly    # present in en_US and en_GB
 cohabitating # present in en_US
 enterprize   # present in en_US

--- a/dictionaries/en_shared/src/exclude-words.txt
+++ b/dictionaries/en_shared/src/exclude-words.txt
@@ -2,3 +2,6 @@
 colum
 knifes
 midwifes
+unwieldly    # present in en_US and en_GB
+cohabitating # present in en_US
+enterprize   # present in en_US

--- a/dictionaries/en_shared/src/shared-additional-words.txt
+++ b/dictionaries/en_shared/src/shared-additional-words.txt
@@ -23,7 +23,7 @@ Christoph
 cohabitate
 cohabitated
 cohabitates
-cohabitating
+cohabiting
 cohabitator
 cohabitators
 comfortability
@@ -167,7 +167,7 @@ unplated
 unprefixed
 unpruned
 unsized
-unwieldly
+unwieldy
 upvoted
 walk-through
 walk-throughs


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _en_US & en_GB_

## Description

- **Fix some typos in English dictionaries**

  - enterprize: wrongly present in en_US
  - cohabitating: wrongly present in en_US
  - unwieldly: wrongly present in en_US and en_GB

enterprise, cohabiting and unwieldy are the correct forms.
They are already in dictionaries.

- **chore: add missing comments to excluded words**

## References

- _Any source references._

## Checklist

- [X] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [X] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
