### PR TITLE
fix: add variations of commit to software corrections

### DIFF
--- a/dictionaries/software-terms/cspell-corrections.yaml
+++ b/dictionaries/software-terms/cspell-corrections.yaml
@@ -53,3 +53,23 @@ dictionaryDefinitions:
       - transfor->transfer, transform
       - verticies->vertices
       - warnining->warning
+
+      - comited->committed
+      - commited->committed
+      - comitted->committed
+
+      - commiter->committer
+      - comiter->committer
+      - comitter->committer
+
+      - commiters->committers
+      - comiters->committers
+      - comitters->committers
+
+      - comitting->committing
+      - comiting->committing
+      - commiting->committing
+
+      - commitable->committable
+      - comitable->committable
+      - comittable->committable


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _software-terms_

## Description

- feat: add variations of commit to software corrections

committer, committers, commitable, committing are very oftenly wrongly written by developpers.

feat: add variations of commit to software corrections

committer, committers, committable, committing are often wrongly written by developers.

Please note, I noticed some of these words are already in [en-common-misspellings](https://github.com/streetsidesoftware/cspell-dicts/tree/main/dictionaries/en-common-misspellings) dictionary, but this one is licensed with a restrictive license: CC BY-SA 4.0
It's better to have them in this dictionary that is licensed with MIT.

## References

- _Any source references._

## Checklist

- [X] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [X] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
