### PR TITLE
fix: Enable git dictionary for commit-msg

### DIFF
--- a/dictionaries/git/cspell-ext.json
+++ b/dictionaries/git/cspell-ext.json
@@ -89,6 +89,10 @@
                 }
             ],
             "ignoreRegExpList": ["git-commit-msg-comment"]
+        },
+        {
+            "languageId": "commit-msg,git-commit",
+            "dictionaries": ["git"]
         }
     ],
     "overrides": [


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _git_

## Description

Enabled the `git` dictionary when the file type is either git-commit -r commit-msg.

Related to #4451

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
