### PR TITLE
chore: add software-terms-legacy.txt

### DIFF
--- a/dictionaries/software-terms/README.md
+++ b/dictionaries/software-terms/README.md
@@ -46,6 +46,10 @@ Building is only necessary if you want to modify the contents of the dictionary.
 npm run build
 ```
 
+## Adding Words
+
+Contributions are welcomed and encouraged, please read [src/README.md](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/software-terms/src/README.md).
+
 ## License
 
 MIT

--- a/dictionaries/software-terms/cspell-tools.config.yaml
+++ b/dictionaries/software-terms/cspell-tools.config.yaml
@@ -9,6 +9,8 @@ targets:
         split: true
       - filename: src/software-terms.txt
         split: true
+      - filename: src/software-terms-legacy.txt
+        split: true
     format: plaintext
     targetDirectory: './dict'
     generateNonStrict: false

--- a/dictionaries/software-terms/src/README.md
+++ b/dictionaries/software-terms/src/README.md
@@ -27,11 +27,9 @@ but encountered while writing code.
 > It also contains tools, products, applications, and even some brands, all these are now in other files from this dictionary.
 
 > [!WARNING]
-> For compatibility reason, no words should be removed from this dictionary, it would break the CI of some projects.
+> For compatibility reason, please move non-relevant words into the [software-terms-legacy.txt](./software-terms-legacy.txt) or one of the other word lists. This will help with future clean up.
 >
-> Instead, please move them into the [software-terms-legacy.txt](./software-terms-legacy.txt).
->
-> They will remain in the `software-terms` dictionary by doing so, and they will be clearly identified.
+> Words moved to software-terms-legacy.txt will remain in the `software-terms` dictionary by doing so they will be clearly identified for possible deprecation.
 
 ### Software Tools
 

--- a/dictionaries/software-terms/src/README.md
+++ b/dictionaries/software-terms/src/README.md
@@ -24,7 +24,6 @@ but encountered while writing code.
 > [!NOTE]
 > This file is unfortunately the result of years of contributions without clear rules.
 > It is known to contain words that should not be in this `software-terms` dictionary.
-> It contains words that should have been added to English or `en_shared` dictionaries.
 > It also contains tools, products, applications, and even some brands, all these are now in other files from this dictionary.
 
 > [!WARNING]

--- a/dictionaries/software-terms/src/README.md
+++ b/dictionaries/software-terms/src/README.md
@@ -2,43 +2,56 @@
 
 Please feel free to make suggestions, additions, and corrections.
 
-There is an ongoing attempt to have the terms in the correct file.
+## Adding Words
 
-## Software Terms
+Contributions are welcomed and encouraged, please read this whole file to figure out where to add words.
 
-This file should contain software terms and concepts. Rule of thumb: [software-terms.txt](./software-terms.txt) should contains
-terms and concepts taught in a software development course. General terms used while coding should be added to [coding-terms.txt](./coding-terms.txt).
-Due to how the file evolved, this file also contains tools, products, applications, and even some brands.
-If you see these, please move them into the correct file.
+### Dictionary structure
 
-- [software-terms.txt](./software-terms.txt) - Concepts.
+### Computing Acronyms
+
 - [computing-acronyms.txt](./computing-acronyms.txt) - Acronyms and abbreviations.
 
-## Coding Terms -- General words used while coding
+### Coding Terms -- General words used while coding
 
-[Coding Terms](./coding-terms.txt) is a good place for general words used while coding. These words are uncommon in general English speech and writing,
+- [coding-terms.txt](./coding-terms.txt) is a good place for general words used while coding. These words are uncommon in general English speech and writing,
 but encountered while writing code.
 
-- [coding-terms.txt](./coding-terms.txt)
+### Software Terms
 
-## Software Tools
+- [software-terms.txt](./software-terms.txt) - Concepts and terms taught in a software development course.
+
+> [!NOTE]
+> This file is unfortunately the result of years of contributions without clear rules.
+> It is known to contain words that should not be in this `software-terms` dictionary.
+> It contains words that should have been added to English or `en_shared` dictionaries.
+> It also contains tools, products, applications, and even some brands, all these are now in other files from this dictionary.
+
+> [!WARNING]
+> For compatibility reason, no words should be removed from this dictionary, it would break the CI of some projects.
+>
+> Instead, please move them into the [software-terms-legacy.txt](./software-terms-legacy.txt).
+>
+> They will remain in the `software-terms` dictionary by doing so, and they will be clearly identified.
+
+### Software Tools
 
 This file contains common tools, applications, products, and services used in the development of software.
 
 - [software-tools.txt](./software-tools.txt)
 
-## Software Web Services / APIs
+### Software Web Services / APIs
 
 - [software-services.txt](./software-services.txt) file contains web service names and terms related to those services.
 
-## Networking
+### Networking
 
 Terms specific to networking and communication.
 
 - [network-protocols.txt](./network-protocols.txt) - Networking Protocols
 - [network-os.txt](./network-os.txt) - Networking Operating Systems
 
-## Cybersecurity
+### Cybersecurity
 
 Cybersecurity related terms.
 

--- a/dictionaries/software-terms/src/software-terms-legacy.txt
+++ b/dictionaries/software-terms/src/software-terms-legacy.txt
@@ -1,0 +1,11 @@
+# Legacy Software Terms
+#
+# This file is only the recipient of terms that should not be in the `software-terms` dictionary.
+# But for compatibility reason, they must remain in this dictionary.
+#
+# More information about in the ./README.md file.
+#
+# Add terms at the end of this file, it minimizes the risks of facing Git conflicts.
+# Terms will get automatically sorted and deduplicated by CI once merged
+#
+# Please add new terms above this line, one per line. They will get automatically sorted.

--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -1,11 +1,22 @@
-# Software Concepts and common terminology
-# This file has grow quite large and contains words that would
-# be better in another file. Before adding a word, consider if it is
-# a concept (like routing, sorting, encryption) or a common coding word (hover, unroute, unmangle).
-# Please add common coding words to ./coding-terms.txt
-# Please add tools to ./software-tools.txt
-# Please add services to ./software-services.txt
-# Please add new terms below this line, one per line. They will get automatically sorted.
+# Software Concepts and terms
+#
+# This file is about concepts and terms that are taught in a software development course.
+#
+# Please follow ./README.md instructions, here is a summary:
+#
+# This file is not about:
+# - acronyms and abbreviations, use ./computing-acronyms.txt
+# - common coding words, use ./coding-terms.txt
+# - software tools, se ./software-tools.txt
+# - software services/API names, use ./software-services.txt
+#
+# This file is the result of years of contributions without clear rules.
+# It is known to contain words that should not be in this dictionary.
+# Please move terms to ./software-terms-legacy.txt if needed.
+# More information in the ./README.md file.
+#
+# Add terms at the end of this file, it minimizes the risks of facing Git conflicts.
+# Terms will get automatically sorted and deduplicated by CI once merged
 AAAI
 abortable
 accessor
@@ -2217,3 +2228,4 @@ zip
 zlib
 ZPool
 ZPools
+# Please add new terms above this line, one per line. They will get automatically sorted.

--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -4,7 +4,7 @@
 #
 # Please follow ./README.md instructions, here is a summary:
 #
-# This file is not about:
+# Add the following type of words to the appropriate files:
 # - acronyms and abbreviations, use ./computing-acronyms.txt
 # - common coding words, use ./coding-terms.txt
 # - software tools, se ./software-tools.txt


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _software-terms_

## Description

The content of software-terms.txt comes from years of contributions.
It doesn't reflect the expected content of the software-terms dictionary.

This PR is about setting up the software-terms-legacy.txt file, and its addition to software-terms dictionary.

Other PRs will follow to move the outdated content from software-terms.txt to software-terms-legacy.txt

## References

This PR replaces #4443

- https://github.com/streetsidesoftware/cspell-dicts/pull/4443

## Checklist

- [X] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [X] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
