### PR TITLE
chore: Add src to en-common-misspellings

### DIFF
--- a/dictionaries/en-common-misspellings/src/LICENSE
+++ b/dictionaries/en-common-misspellings/src/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017-2025 Street Side Software <support@streetsidesoftware.nl>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/dictionaries/en-common-misspellings/src/README.md
+++ b/dictionaries/en-common-misspellings/src/README.md
@@ -1,0 +1,4 @@
+# Source for suggestions
+
+Use [`additional-suggestions.txt`](./additional-suggestions.txt) to add new suggestions.
+They will automatically get added to the dictionary.

--- a/dictionaries/en-common-misspellings/src/additional-suggestions.txt
+++ b/dictionaries/en-common-misspellings/src/additional-suggestions.txt
@@ -1,0 +1,7 @@
+# Add additional suggestions here.
+# the form is:
+# misspelling->suggestion
+#
+# Tell cspell to not spell check the misspelled words:
+# cspell:ignoreRegExp /^\w+->/gm
+enterprizze->enterprise


### PR DESCRIPTION

# Add/Fix Dictionary

Dictionary: en-common-misspellings

## Description

Set up a src directory with an MIT license so we can use the suggestions in other places.


## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
