### PR TITLE
feat: add en_shared -ize forms to en_GB-MIT

### DIFF
--- a/dictionaries/en_GB-MIT/cspell-tools.config.yaml
+++ b/dictionaries/en_GB-MIT/cspell-tools.config.yaml
@@ -11,6 +11,7 @@ targets:
       - ./node_modules/@cspell/dict-en-shared/dict/acronyms.txt
       - ./node_modules/@cspell/dict-en-shared/dict/shared-additional-words.txt
       - ./node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ise.txt
+      - ./node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ize.txt
       - ./src/acronyms.txt
       - ./src/additional_words.txt
       - ./src/legacy/wordsEnGb.txt
@@ -96,6 +97,7 @@ targets:
       - ./node_modules/@cspell/dict-en-shared/dict/acronyms.txt
       - ./node_modules/@cspell/dict-en-shared/dict/shared-additional-words.txt
       - ./node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ise.txt
+      - ./node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ize.txt
       - ./src/acronyms.txt
       - ./src/additional_words.txt
       - ./src/block_words.txt


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _en_GB-MIT_

## Description

Add en_shared -ize form to en_GB-MIT dictionary

## References

This comment was left behind in a previous PR because it was resolved, but it was valuable.

> Yes, en_GB-MIT is good. Any shared additions should go there as long as they are under the MIT license.
> _Originally posted by @Jason3S in https://github.com/streetsidesoftware/cspell-dicts/pull/4438#discussion_r2108307413_

## Checklist

- [X] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [X] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
