### PR TITLE
chore: improve en_shared README files

### DIFF
--- a/dictionaries/en_shared/README.md
+++ b/dictionaries/en_shared/README.md
@@ -3,3 +3,29 @@
 Note this is a private package used to store and track changes to the shared English words.
 
 It not designed to be published.
+
+The word lists in this dictionary are imported by other English dictionaries.
+
+## Adding Words
+
+Contributions are welcomed and encouraged, please read [src/README.md](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_shared/src/README.md).
+
+## License
+
+MIT
+
+> Some packages may have other licenses included.
+
+<!--- @@inject: ../../static/footer.md --->
+
+<br/>
+
+---
+
+<p align="center">
+Brought to you by <a href="https://streetsidesoftware.com" title="Street Side Software">
+<img width="16" alt="Street Side Software Logo" src="https://i.imgur.com/CyduuVY.png" /> Street Side Software
+</a>
+</p>
+
+<!--- @@inject-end: ../../static/footer.md --->

--- a/dictionaries/en_shared/src/README.md
+++ b/dictionaries/en_shared/src/README.md
@@ -2,13 +2,36 @@
 
 All source files used to generate the English dictionaries should be stored in this directory.
 
+## Remarks about `-ize` and `-ise` words
+
+[!NOTE]
+> `-ize` words are not specific to US English (`en_US`)
+> US Americans chose to use them over `-ise` words.
+>
+> For this reason, most of the `-ise` words are not correct for US English
+
+The truth is that `-ize` words originated in British English (`en_GB`).
+The Oxford English dictionary prefers `-ize` over `-ise`.
+Which is why the original British English dictionary (`en_GB`) included `-ize` variants.
+
+The `en_GB-ise` dictionary is the British English dictionary without the `-ize` variants.
+
+Canadian English (`en_CA`) & Australian English (`en_CA`) use both `-ise` and `-ize` forms.
+
 ## Adding words
 
 If the words you want to add is valid for:
 
-- For words in all English variants (en_US, en_AU, en_CA, en_GB, ...),
+- For words in **all English variants** (`en_US`, `en_AU`, `en_CA`, `en_GB`, ...),
   add them to [shared-additional-words.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_shared/src/shared-additional-words.txt)
-- For American English (en_US) and Oxford English (en_GB) words ending in `ize`,
+- For American English (`en_US`) and Oxford English (`en_GB`) words ending in `ize`,
   add them to [shared-additional-words-ize.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_shared/src/shared-additional-words-ize.txt)
-- For non-American English variants (en_AU, en_CA, en_GB-ise, ...),
+- For non-American English variants (`en_AU`, `en_CA`, `en_GB-ise`, ...),
   add them to [shared-additional-words-ise.txt](https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/en_shared/src/shared-additional-words-ise.txt)
+
+## License
+
+MIT
+
+> Some packages may have other licenses included.
+


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _en_shared_

## Description

The idea is to provide a more comprehensive overview of the English
dictionaries and their structure, making it easier for contributors to
understand the purpose of each file and how to contribute effectively.

## References

> -ize words are not American. Americans chose to use them over -ise words, but the truth is that -ize words originated in British English. The Oxford English dictionary prefers -ize over -ise. Which is why the original British English dictionary included -ize variants. 
> _Originally posted by @Jason3S in https://github.com/streetsidesoftware/cspell-dicts/pull/4438#discussion_r2086072643_
   
> In general, most of the `-ise` words are not correct for US English. If it is an `-ise` word that is used in all variants, then it should be added to `shared-additional-words.txt` instead. The converse is true for `-ize` words, if they are correct for all variants, then they should be added `shared-additional-words.txt`, otherwise `-ise`.
>_Originally posted by @Jason3S in https://github.com/streetsidesoftware/cspell-dicts/pull/4438#discussion_r2108317782_
                     

## Checklist

- [X] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [X] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
