### PR TITLE
fix: add 'helm' and 'helmfile' to software tools dictionary

### DIFF
--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -145,6 +145,8 @@ haproxy
 HashiCorp
 hdiutil
 HelloSign
+helm # Package manager for k8s
+helmfile # Declarative spec for deploying helm charts
 helmify
 Hibernate Envers
 HipChat


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: `software-tools.txt`

## Description

Add 'helm' and 'helmfile' to software tools dictionary

Not sure if these should go here or in the k8s dictionary.

## References

- https://helm.sh/
- https://helmfile.readthedocs.io

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
