### PR TITLE
fix: add 'unbundle'

### DIFF
--- a/dictionaries/npm/dict/npm.txt
+++ b/dictionaries/npm/dict/npm.txt
@@ -2584,6 +2584,7 @@ uj-apidoc-core
 ulid
 ultrahtml
 unbuild
+unbundle
 unde-vitae-reprehenderit
 underscore
 undici

--- a/dictionaries/npm/src/npm.txt
+++ b/dictionaries/npm/src/npm.txt
@@ -2600,6 +2600,7 @@ uj-apidoc-core
 ulid
 ultrahtml
 unbuild
+unbundle
 underscore
 underscore.string
 undici


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: _npm_

## Description

Adds _unbundle_, a new config option in tsdown.

## References

- https://tsdown.dev/reference/config-options#unbundle

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
