### PR TITLE
fix: Add `unbundle` to English shared

### DIFF
--- a/dictionaries/en_shared/src/shared-additional-words.txt
+++ b/dictionaries/en_shared/src/shared-additional-words.txt
@@ -173,3 +173,8 @@ walk-through
 walk-throughs
 wirelessly
 unbundle
+unbundled
+unbundling
+unbundlings
+unbundles
+telecom

--- a/dictionaries/en_shared/src/shared-additional-words.txt
+++ b/dictionaries/en_shared/src/shared-additional-words.txt
@@ -172,3 +172,4 @@ upvoted
 walk-through
 walk-throughs
 wirelessly
+unbundle


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: English All

## Description

- `unbundle` - is a common term, often with respect to unbundling telecom packages.

## References

- https://www.merriam-webster.com/dictionary/unbundle
- https://dictionary.cambridge.org/dictionary/english/unbundle

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
