### PR TITLE
fix: add missing 'nodenext' to dict/typescript.txt

### DIFF
--- a/dictionaries/typescript/dict/typescript.txt
+++ b/dictionaries/typescript/dict/typescript.txt
@@ -2060,6 +2060,7 @@ nfkd
 nicest
 nobr
 node
+nodenext
 nodes
 noflow
 noframes

--- a/dictionaries/typescript/src/typescript.txt
+++ b/dictionaries/typescript/src/typescript.txt
@@ -1918,6 +1918,7 @@ NFKD
 nicest
 nobr
 node
+nodenext
 nodes
 noflow
 noframes


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: _typescript_

## Description

Adds `nodenext` to `typescript`. Similar to https://github.com/streetsidesoftware/cspell-dicts/pull/4095.

## References

- https://www.typescriptlang.org/tsconfig/#node16node18nodenext

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
