### PR TITLE
fix: add 'conventionalcommits'

### DIFF
--- a/dictionaries/software-terms/dict/software-tools.txt
+++ b/dictionaries/software-terms/dict/software-tools.txt
@@ -241,6 +241,7 @@ codeql
 codicon
 codicons
 conda
+conventionalcommits
 corepack
 cron
 cspell

--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -66,6 +66,7 @@ codeql
 codicon
 codicons
 conda
+conventionalcommits
 corepack
 Couchbase # Couchbase Database
 CouchDB


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: _software-tools_

## Description

Adds "conventionalcommits"

## References

- conventionalcommits.org
- https://github.com/streetsidesoftware/cspell-dicts/blob/4003ea4fffec78c904a130be9edda880b64b1159/lerna.json#L12

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
