### PR TITLE
chore(de_DE): format and sort CHANGELOG entry for 2.1.0 correctly

### DIFF
--- a/dictionaries/de_DE/CHANGELOG.md
+++ b/dictionaries/de_DE/CHANGELOG.md
@@ -3,16 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [2.1.0](https://github.com/streetsidesoftware/cspell-dicts/compare/@cspell/dict-de-de@2.0.2...@cspell/dict-de-de@2.1.0) (2021-11-04)
-
-
-### Features
-
-* Make German case and accent sensitive by default. ([#748](https://github.com/streetsidesoftware/cspell-dicts/issues/748)) ([afea23d](https://github.com/streetsidesoftware/cspell-dicts/commit/afea23d9c312cb818e0a50c00fe1d0b282be9b06))
-
-
-
-
 
 ## [4.1.0](https://github.com/streetsidesoftware/cspell-dicts/compare/@cspell/dict-de-de@4.0.3...@cspell/dict-de-de@4.1.0) (2025-04-16)
 
@@ -117,6 +107,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * adjust the trie format to improve git storage ([#1371](https://github.com/streetsidesoftware/cspell-dicts/issues/1371)) ([1b91dc7](https://github.com/streetsidesoftware/cspell-dicts/commit/1b91dc7ff869ca1d7ece87910da9adce12504085))
 * do not store `.trie.gz` files. ([#1361](https://github.com/streetsidesoftware/cspell-dicts/issues/1361)) ([2de0b0d](https://github.com/streetsidesoftware/cspell-dicts/commit/2de0b0df4b8addfd69e2e6899c05f8b502799b7c))
 * force overwrite in prepare ([#1364](https://github.com/streetsidesoftware/cspell-dicts/issues/1364)) ([5eec47e](https://github.com/streetsidesoftware/cspell-dicts/commit/5eec47e223f1dd6370fcbc3c1b6b0361c92bbddf))
+
+
+## [2.1.0](https://github.com/streetsidesoftware/cspell-dicts/compare/@cspell/dict-de-de@2.0.2...@cspell/dict-de-de@2.1.0) (2021-11-04)
+
+
+### Features
+
+* Make German case and accent sensitive by default. ([#748](https://github.com/streetsidesoftware/cspell-dicts/issues/748)) ([afea23d](https://github.com/streetsidesoftware/cspell-dicts/commit/afea23d9c312cb818e0a50c00fe1d0b282be9b06))
+
 
 ## [2.0.2](https://github.com/streetsidesoftware/cspell-dicts/compare/@cspell/dict-de-de@2.0.1...@cspell/dict-de-de@2.0.2) (2021-09-16)
 


### PR DESCRIPTION
<!---
name: format and sort de_DE CHANGELOG entry for 2.1.0 correctly
about: CHANGELOG entry vor `2.1.0` was malformed (H1 instead of H2) and, therefore, sorted incorrectly to the top. This fixes the changeling by formatting the entry as an H2 (`##`) and sorting the entry to the correct position.
title: 'chore(de_DE): format and sort CHANGELOG entry for 2.1.0 correctly'
labels:
--->

# Add/Fix Dictionary

Dictionary: de_DE

## Description

CHANGELOG entry vor `2.1.0` was malformed (H1 instead of H2) and, therefore, sorted incorrectly to the top. This fixes the changeling by formatting the entry as an H2 (`##`) and sorting the entry to the correct position.

## References

N/A

## Checklist

- [X] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [X] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
