### PR TITLE
chore: add dockerizes and dockerizing to dictionaries

### DIFF
--- a/dictionaries/docker/src/docker-words.txt
+++ b/dictionaries/docker/src/docker-words.txt
@@ -25,8 +25,9 @@ dockerenv
 dockerfile
 Dockerfile
 dockerignore
-Dockerize
-Dockerized
+dockerize
+dockerized
+dockerizing
 ENTRYPOINT
 ENV
 escape


### PR DESCRIPTION

<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _Docker_

## Description

The verb "to dockerize" is derived from the noun "Docker".

Add dockerizes and dockerizing.

They should not be capitalized as they are not proper nouns, unless
they are at the beginning of a sentence.
For this reason, the words "Dockerize" and "Dockerized" are removed.


## References

- https://github.com/streetsidesoftware/cspell-dicts/pull/4678#issuecomment-3095309135

## Checklist

- [X] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [X] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.

this follows #4678 PR

- https://github.com/streetsidesoftware/cspell-dicts/pull/4678#issuecomment-3095309135