### PR TITLE
fix: add lefthook to npm dictionary

### DIFF
--- a/dictionaries/npm/dict/npm.txt
+++ b/dictionaries/npm/dict/npm.txt
@@ -1415,6 +1415,7 @@ lead-alike-web3-applied
 leaflet
 leaflet-gesture-handling
 left-pad
+lefthook
 leftpad
 legacy-modal
 legacy-provider

--- a/dictionaries/npm/src/npm.txt
+++ b/dictionaries/npm/src/npm.txt
@@ -1626,6 +1626,7 @@ lazy.js
 lead-alike-web3-applied
 leaflet
 leaflet-gesture-handling
+lefthook
 left-pad
 leftpad
 lerna


### PR DESCRIPTION
<!---
name: Add lefthook to NPM Dictionary
about: PR for adding (to) a dictionary
title: 'fix: add lefthook to npm dictionary'
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary:  NPM

## Description

Adds lefthook to the npm library

## References

https://lefthook.dev/

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
