### PR TITLE
fix: add software terms

### DIFF
--- a/dictionaries/en_shared/dict/shared-additional-words.txt
+++ b/dictionaries/en_shared/dict/shared-additional-words.txt
@@ -66,6 +66,7 @@ eligibilities
 endoliths
 esports
 ethnicities
+evaluable
 exfiltrate
 freemium
 futhorc

--- a/dictionaries/en_shared/src/shared-additional-words.txt
+++ b/dictionaries/en_shared/src/shared-additional-words.txt
@@ -61,6 +61,7 @@ eligibilities
 endoliths
 esports
 ethnicities
+evaluable
 exfiltrate
 freemium
 futhorc

--- a/dictionaries/software-terms/dict/softwareTerms.txt
+++ b/dictionaries/software-terms/dict/softwareTerms.txt
@@ -1105,6 +1105,7 @@ errormessage
 eslint
 esquery
 eval
+evaluable
 evaluatable
 event
 eventLog
@@ -2842,6 +2843,7 @@ unnormalizing
 unopinionated
 unoptimized
 unordered
+unpackable
 unpackage
 unpackaged
 unparenthesized

--- a/dictionaries/software-terms/dict/softwareTerms.txt
+++ b/dictionaries/software-terms/dict/softwareTerms.txt
@@ -1105,7 +1105,6 @@ errormessage
 eslint
 esquery
 eval
-evaluable
 evaluatable
 event
 eventLog

--- a/dictionaries/software-terms/src/coding-terms.txt
+++ b/dictionaries/software-terms/src/coding-terms.txt
@@ -840,6 +840,7 @@ unnormalized
 unnormalizer
 unnormalizing
 unoptimized
+unpackable
 unpackage
 unpackaged
 unparenthesized

--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -646,7 +646,6 @@ ESNEXT
 ETag # entity tag
 ETags
 eval
-evaluable
 evaluatable
 event
 evolvability

--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -646,6 +646,7 @@ ESNEXT
 ETag # entity tag
 ETags
 eval
+evaluable
 evaluatable
 event
 evolvability


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: _software-terms_

## Description

Added the following two terms:
* `evaluable` - same as the existing `evaluatable`, but a more standard form and more commonly found in dictionaries [1, 2]
* `unpackable` - common coding term for objects that can be unpacked

## References

1. https://www.merriam-webster.com/dictionary/evaluable
2. https://www.oed.com/dictionary/evaluable_adj
3. https://glosbe.com/en/en/evaluable
4. https://glosbe.com/en/en/unpackable

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
