### PR TITLE
fix: Remove `typw` from the English dictionary

### DIFF
--- a/dictionaries/en-common-misspellings/cspell-ext.json
+++ b/dictionaries/en-common-misspellings/cspell-ext.json
@@ -14,12 +14,12 @@
         {
             "languageId": "*",
             "locale": "en-gb",
-            "dictionaries": ["en-gb-common-misspellings"]
+            "dictionaries": ["en-common-misspellings", "en-gb-common-misspellings"]
         },
         {
             "languageId": "*",
             "locale": "en-us",
-            "dictionaries": ["en-us-common-misspellings"]
+            "dictionaries": ["en-common-misspellings", "en-us-common-misspellings"]
         }
     ]
 }

--- a/dictionaries/en-common-misspellings/dict/dict-en.json
+++ b/dictionaries/en-common-misspellings/dict/dict-en.json
@@ -63197,6 +63197,7 @@
     "typpos->typos",
     "typs->typos",
     "typscript->typescript",
+    "typw->type",
     "tyranies->tyrannies",
     "tyrannia->tyrannical",
     "tyrantical->tyrannical",

--- a/dictionaries/en-common-misspellings/src/dict-en.txt
+++ b/dictionaries/en-common-misspellings/src/dict-en.txt
@@ -24,4 +24,5 @@ remnats->remnants
 shis->this
 signiory->seigniory
 signory->seigniory
+typw->type
 witten->written

--- a/dictionaries/en_AU/checksum.txt
+++ b/dictionaries/en_AU/checksum.txt
@@ -1,8 +1,8 @@
-2110dca0eae51ebefa4245f0e8c954cc4e3235e5  en_AU.trie
+0fd5177f7524f9d870f3ef742036cc71d8223006  en_AU.trie
 bf973d4e9a056973925e9fa15834d83ac3c8a7c6  node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_AU (Kevin Atkinson)/en_AU.aff
 21191f1108e608d1b96076d141586fccd6c79a1c  node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_AU (Kevin Atkinson)/en_AU.dic
 cbe44d3a8178f7215b5ea1089fc420b435ea2666  node_modules/@cspell/dict-en-shared/dict/acronyms.txt
-3d203a0e51d82c0d9609d743cc9ff448eec50601  node_modules/@cspell/dict-en-shared/dict/exclude-words.txt
+b1bfcc204263ecf4c623bc404a459519fb3bf19a  node_modules/@cspell/dict-en-shared/dict/exclude-words.txt
 08b1d79270bddbafdf876f4fe432193d119275d9  node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ise.txt
 65d9f69aaa86aaf841689e130983ea0a6abd53fd  node_modules/@cspell/dict-en-shared/dict/shared-additional-words.txt
 dcdb0536389ef56c4525373744345163e3d23494  src/additional_words.txt

--- a/dictionaries/en_AU/cspell-ext.json
+++ b/dictionaries/en_AU/cspell-ext.json
@@ -1,46 +1,28 @@
-// cSpell Settings
 {
     "id": "en-au",
     "name": "English - Australian",
     "description": "Australian English Dictionary",
     "readonly": true,
-    // List of dictionary files to add to the global list of dictionaries
     "dictionaryDefinitions": [
         {
             "name": "en-au",
             "path": "./en_AU.trie",
             "repMap": [["'|`|’", "'"]],
-            "description": "Australian English Dictionary"
+            "description": "Australian English Dictionary",
+            "ignoreForbiddenWords": true
         }
     ],
-    // Dictionaries to always be used.
-    // Generally left empty
-    "dictionaries": [],
-    // Language Rules to apply to matching files.
-    // Files are matched on `languageId` and `locale`
     "languageSettings": [
         {
-            // VSCode languageId. i.e. typescript, java, go, cpp, javascript, markdown, latex
-            // * will match against any file type.
             "languageId": "*",
-            // Language locale. i.e. en-US, de-AT, or ru. * will match all locals.
             "locale": "en-AU",
-            //
-            "ignoreRegExpList": [],
-            "includeRegExpList": [],
-            // regex patterns than can be used with ignoreRegExpList or includeRegExpList
-            // Example: "pattern": [{ "name": "mdash", "pattern": "&mdash;" }]
-            // This could be included in "ignoreRegExpList": ["mdash"]
             "patterns": [
                 {
                     "name": "possessive_s",
                     "pattern": "/'s\\b/gi"
                 }
             ],
-            // List of dictionaries to enable by name in `dictionaryDefinitions`
-            "dictionaries": ["en-au", "en-common-misspellings"],
-            // Dictionary definitions can also be supplied here
-            "dictionaryDefinitions": []
+            "dictionaries": ["en-au", "en-common-misspellings", "en-gb-common-misspellings"]
         }
     ]
 }

--- a/dictionaries/en_AU/en_AU.trie
+++ b/dictionaries/en_AU/en_AU.trie
@@ -5786,7 +5786,7 @@ i#mk;<2$x#4;<2o\'#9;<fe#bb;<o#1vv;<2h#17s5;<p#1nf7;<so#9p8;<$$p$2
 y
 ch#2qq;<oon#11h3;<4g$i#mk;<k#el;<l#gff;<mb#1d8;<pani\'#9;<c$s#9j;<t#ff1;<$s$u#t9;<y$$4pa#6a;<e\'#9;<b#dr;<case$
 t#kst;<4d$f#lc0;<sc#1ag9;<e#jtq;<$write#jut;<i#19d;<t#eo;<3o#g8;<3$hog#jia;<i#2j;<o#6k;<u#9;<2u#65;<2ic#j3q;<f#12rh;<n#gn;<s#9j;<2
-o\'#9;<gr#19e4;<2l#1b7l;<s$$w$$rannica#fd7;<id#mp8;<2$e#9;<s#jgs;<2os#mc5;<u#gbq;<2y#f;<2t#c;<3e#c;<o\'#9;<c#jso;<sin#1e3g;<2$
+o\'#9;<gr#19e4;<2l#1b7l;<s$$$rannica#fd7;<id#mp8;<2$e#9;<s#jgs;<2os#mc5;<u#gbq;<2y#f;<2t#c;<3e#c;<o\'#9;<c#jso;<sin#1e3g;<2$
 t#1ouf;<$3
 z
 ar#c;<tz#266;<4

--- a/dictionaries/en_CA/checksum.txt
+++ b/dictionaries/en_CA/checksum.txt
@@ -1,8 +1,8 @@
-05803ae6ad8fa5b1cfba5191ab3c6d520c101c2f  en_CA.trie
+d9263078f8a7a84ac25ede9d9d0711c5fc12c2ff  en_CA.trie
 bf973d4e9a056973925e9fa15834d83ac3c8a7c6  node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_CA (Kevin Atkinson)/en_CA.aff
 8bcb82e787d390561c0ac4416a811a7323b1ef97  node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_CA (Kevin Atkinson)/en_CA.dic
 cbe44d3a8178f7215b5ea1089fc420b435ea2666  node_modules/@cspell/dict-en-shared/dict/acronyms.txt
-3d203a0e51d82c0d9609d743cc9ff448eec50601  node_modules/@cspell/dict-en-shared/dict/exclude-words.txt
+b1bfcc204263ecf4c623bc404a459519fb3bf19a  node_modules/@cspell/dict-en-shared/dict/exclude-words.txt
 08b1d79270bddbafdf876f4fe432193d119275d9  node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ise.txt
 65d9f69aaa86aaf841689e130983ea0a6abd53fd  node_modules/@cspell/dict-en-shared/dict/shared-additional-words.txt
 b2aa6248b5ba4fcc9cf0f03c62abb78f325c207a  src/additional_words.txt

--- a/dictionaries/en_CA/cspell-ext.json
+++ b/dictionaries/en_CA/cspell-ext.json
@@ -1,46 +1,29 @@
-// cSpell Settings
 {
     "id": "en-ca",
     "name": "English - Canadian",
     "description": "Canadian English Dictionary",
     "readonly": true,
-    // List of dictionary files to add to the global list of dictionaries
     "dictionaryDefinitions": [
         {
             "name": "en-ca",
             "path": "./en_CA.trie",
             "repMap": [["'|`|’", "'"]],
-            "description": "Canadian English Dictionary"
+            "description": "Canadian English Dictionary",
+            "ignoreForbiddenWords": true
         }
     ],
-    // Dictionaries to always be used.
-    // Generally left empty
     "dictionaries": [],
-    // Language Rules to apply to matching files.
-    // Files are matched on `languageId` and `locale`
     "languageSettings": [
         {
-            // VSCode languageId. i.e. typescript, java, go, cpp, javascript, markdown, latex
-            // * will match against any file type.
             "languageId": "*",
-            // Language locale. i.e. en-US, de-AT, or ru. * will match all locals.
             "locale": "en-CA",
-            //
-            "ignoreRegExpList": [],
-            "includeRegExpList": [],
-            // regex patterns than can be used with ignoreRegExpList or includeRegExpList
-            // Example: "pattern": [{ "name": "mdash", "pattern": "&mdash;" }]
-            // This could be included in "ignoreRegExpList": ["mdash"]
             "patterns": [
                 {
                     "name": "possessive_s",
                     "pattern": "/'s\\b/gi"
                 }
             ],
-            // List of dictionaries to enable by name in `dictionaryDefinitions`
-            "dictionaries": ["en-ca", "en-common-misspellings"],
-            // Dictionary definitions can also be supplied here
-            "dictionaryDefinitions": []
+            "dictionaries": ["en-ca", "en-common-misspellings", "en-gb-common-misspellings"]
         }
     ]
 }

--- a/dictionaries/en_CA/en_CA.trie
+++ b/dictionaries/en_CA/en_CA.trie
@@ -5771,8 +5771,7 @@ i#mj;<2$x#4;<2o\'#9;<fe#bb;<o#1vv;<2h#17nh;<p#1n8l;<so#9og;<$$p$2
 y
 ch#2qr;<oon#11d0;<4g$i#mj;<k#ek;<l#gde;<mb#1db;<pani\'#9;<c$s#9j;<t#fd0;<$s$u#t9;<y$$4pa#6a;<e\'#9;<b#dq;<case$
 t#kqr;<4d$f#l9u;<sc#1aba;<e#jrs;<$write#jsv;<i#19g;<t#en;<3o#g7;<3$hog#jgd;<i#2j;<o#6k;<u#9;<2u#65;<2ic#j1s;<f#12n9;<n#gm;<s#9j;<2
-o\'#9;<gr#1994;<2l#1b2n;<s$$w$$rannica#fb7;<id#mmt;<2$e#9;<z#jev;<2os#ma0;<u#g9r;<2y#f;<2t#c;<3o\'#9;<c#jqr;<sin#1due;<2$
-t#1onl;<$3
+o\'#9;<gr#1994;<2l#1b2n;<s$$$rannica#fb7;<id#mmt;<2$e#9;<z#jev;<2os#ma0;<u#g9r;<2y#f;<2t#c;<3o\'#9;<c#jqr;<sin#1due;<2$t#1onl;<$3
 z
 atz#266;<4
 $

--- a/dictionaries/en_GB-MIT/checksum.txt
+++ b/dictionaries/en_GB-MIT/checksum.txt
@@ -13,7 +13,7 @@ bf973d4e9a056973925e9fa15834d83ac3c8a7c6  node_modules/@cspell/aoo-mozilla-en-di
 bf973d4e9a056973925e9fa15834d83ac3c8a7c6  node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_US (Kevin Atkinson)/en_US.aff
 8d744092d04ef72d0b191140a01570be7d2cf7f4  node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_US (Kevin Atkinson)/en_US.dic
 cbe44d3a8178f7215b5ea1089fc420b435ea2666  node_modules/@cspell/dict-en-shared/dict/acronyms.txt
-3d203a0e51d82c0d9609d743cc9ff448eec50601  node_modules/@cspell/dict-en-shared/dict/exclude-words.txt
+b1bfcc204263ecf4c623bc404a459519fb3bf19a  node_modules/@cspell/dict-en-shared/dict/exclude-words.txt
 08b1d79270bddbafdf876f4fe432193d119275d9  node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ise.txt
 bb0784fd8791276ddc1b9978411bf7b603bc9de4  node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ize.txt
 65d9f69aaa86aaf841689e130983ea0a6abd53fd  node_modules/@cspell/dict-en-shared/dict/shared-additional-words.txt

--- a/dictionaries/en_GB-MIT/cspell-ext.json
+++ b/dictionaries/en_GB-MIT/cspell-ext.json
@@ -1,10 +1,8 @@
-// cSpell Settings
 {
     "id": "en-gb-mit",
     "name": "English - British (Limited)",
     "description": "British English Dictionary with MIT License",
     "readonly": true,
-    // List of dictionary files to add to the global list of dictionaries
     "dictionaryDefinitions": [
         {
             "name": "en-gb",
@@ -14,34 +12,17 @@
             "ignoreForbiddenWords": true
         }
     ],
-    // Dictionaries to always be used.
-    // Generally left empty
-    "dictionaries": [],
-    // Language Rules to apply to matching files.
-    // Files are matched on `languageId` and `locale`
     "languageSettings": [
         {
-            // VSCode languageId. i.e. typescript, java, go, cpp, javascript, markdown, latex
-            // * will match against any file type.
             "languageId": "*",
-            // Language locale. i.e. en-US, de-AT, or ru. * will match all locals.
             "locale": "en-GB",
-            //
-            "ignoreRegExpList": [],
-            "includeRegExpList": [],
-            // regex patterns than can be used with ignoreRegExpList or includeRegExpList
-            // Example: "pattern": [{ "name": "mdash", "pattern": "&mdash;" }]
-            // This could be included in "ignoreRegExpList": ["mdash"]
             "patterns": [
                 {
                     "name": "possessive_s",
                     "pattern": "/'s\\b/gi"
                 }
             ],
-            // List of dictionaries to enable by name in `dictionaryDefinitions`
-            "dictionaries": ["en-gb"],
-            // Dictionary definitions can also be supplied here
-            "dictionaryDefinitions": []
+            "dictionaries": ["en-gb"]
         }
     ]
 }

--- a/dictionaries/en_GB-ise/checksum.txt
+++ b/dictionaries/en_GB-ise/checksum.txt
@@ -2,7 +2,7 @@
 19545c3430a7a7884561e260738f98ee5e3e95c2  node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_GB (Marco Pinto) (-ise) (2025+)/en_GB.aff
 1d09910d65cb6ae01c87a214b5ea024cf613ab8a  node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_GB (Marco Pinto) (-ise) (2025+)/en_GB.dic
 cbe44d3a8178f7215b5ea1089fc420b435ea2666  node_modules/@cspell/dict-en-shared/dict/acronyms.txt
-3d203a0e51d82c0d9609d743cc9ff448eec50601  node_modules/@cspell/dict-en-shared/dict/exclude-words.txt
+b1bfcc204263ecf4c623bc404a459519fb3bf19a  node_modules/@cspell/dict-en-shared/dict/exclude-words.txt
 08b1d79270bddbafdf876f4fe432193d119275d9  node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ise.txt
 65d9f69aaa86aaf841689e130983ea0a6abd53fd  node_modules/@cspell/dict-en-shared/dict/shared-additional-words.txt
 8b90017b5d39d4837b4b7f925f1bf2e3ea32de70  src/additional_words.txt

--- a/dictionaries/en_GB-ise/cspell-ext.json
+++ b/dictionaries/en_GB-ise/cspell-ext.json
@@ -8,7 +8,8 @@
             "name": "en-gb",
             "path": "./en_GB.trie.gz",
             "repMap": [["'|`|’", "'"]],
-            "description": "British English Dictionary"
+            "description": "British English Dictionary",
+            "ignoreForbiddenWords": true
         }
     ],
     "languageSettings": [

--- a/dictionaries/en_GB-legacy/checksum.txt
+++ b/dictionaries/en_GB-legacy/checksum.txt
@@ -3,7 +3,7 @@
 19545c3430a7a7884561e260738f98ee5e3e95c2  node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_GB (Marco Pinto) (-ise -ize) (2025+)/en_GB.aff
 00e91788594ad62050423789a24aa0fe1212445d  node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_GB (Marco Pinto) (-ise -ize) (2025+)/en_GB.dic
 cbe44d3a8178f7215b5ea1089fc420b435ea2666  node_modules/@cspell/dict-en-shared/dict/acronyms.txt
-3d203a0e51d82c0d9609d743cc9ff448eec50601  node_modules/@cspell/dict-en-shared/dict/exclude-words.txt
+b1bfcc204263ecf4c623bc404a459519fb3bf19a  node_modules/@cspell/dict-en-shared/dict/exclude-words.txt
 08b1d79270bddbafdf876f4fe432193d119275d9  node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ise.txt
 65d9f69aaa86aaf841689e130983ea0a6abd53fd  node_modules/@cspell/dict-en-shared/dict/shared-additional-words.txt
 e005e6366b9076d32aea571da7c09448e1c4cd86  src/wordsEnGb.txt

--- a/dictionaries/en_GB-legacy/cspell-ext.json
+++ b/dictionaries/en_GB-legacy/cspell-ext.json
@@ -8,7 +8,8 @@
             "name": "en-gb-legacy",
             "path": "./dict/en_GB-legacy.trie.gz",
             "repMap": [["'|`|’", "'"]],
-            "description": "Legacy British English Dictionary"
+            "description": "Legacy British English Dictionary",
+            "ignoreForbiddenWords": true
         }
     ],
     "languageSettings": [

--- a/dictionaries/en_GB/checksum.txt
+++ b/dictionaries/en_GB/checksum.txt
@@ -2,7 +2,7 @@ e5e87f9ad2606344574ba0c20f8460901e9c78be  en_GB.trie
 19545c3430a7a7884561e260738f98ee5e3e95c2  node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_GB (Marco Pinto) (-ise -ize) (2025+)/en_GB.aff
 00e91788594ad62050423789a24aa0fe1212445d  node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_GB (Marco Pinto) (-ise -ize) (2025+)/en_GB.dic
 cbe44d3a8178f7215b5ea1089fc420b435ea2666  node_modules/@cspell/dict-en-shared/dict/acronyms.txt
-3d203a0e51d82c0d9609d743cc9ff448eec50601  node_modules/@cspell/dict-en-shared/dict/exclude-words.txt
+b1bfcc204263ecf4c623bc404a459519fb3bf19a  node_modules/@cspell/dict-en-shared/dict/exclude-words.txt
 08b1d79270bddbafdf876f4fe432193d119275d9  node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ise.txt
 bb0784fd8791276ddc1b9978411bf7b603bc9de4  node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ize.txt
 65d9f69aaa86aaf841689e130983ea0a6abd53fd  node_modules/@cspell/dict-en-shared/dict/shared-additional-words.txt

--- a/dictionaries/en_GB/cspell-ext.json
+++ b/dictionaries/en_GB/cspell-ext.json
@@ -8,7 +8,8 @@
             "name": "en-gb",
             "path": "./en_GB.trie.gz",
             "repMap": [["'|`|’", "'"]],
-            "description": "British English Dictionary"
+            "description": "British English Dictionary",
+            "ignoreForbiddenWords": true
         }
     ],
     "languageSettings": [

--- a/dictionaries/en_US/checksum.txt
+++ b/dictionaries/en_US/checksum.txt
@@ -1,8 +1,8 @@
-cc2134ffeab78e35ae84fded6c7e293fb01b15fd  en_US.trie
+58e72a7a5a97b5ee27f8f92f0bd8cf128e7029f8  en_US.trie
 bf973d4e9a056973925e9fa15834d83ac3c8a7c6  node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_US (Kevin Atkinson)/en_US.aff
 8d744092d04ef72d0b191140a01570be7d2cf7f4  node_modules/@cspell/aoo-mozilla-en-dict/dicts/en_US (Kevin Atkinson)/en_US.dic
 cbe44d3a8178f7215b5ea1089fc420b435ea2666  node_modules/@cspell/dict-en-shared/dict/acronyms.txt
-3d203a0e51d82c0d9609d743cc9ff448eec50601  node_modules/@cspell/dict-en-shared/dict/exclude-words.txt
+b1bfcc204263ecf4c623bc404a459519fb3bf19a  node_modules/@cspell/dict-en-shared/dict/exclude-words.txt
 bb0784fd8791276ddc1b9978411bf7b603bc9de4  node_modules/@cspell/dict-en-shared/dict/shared-additional-words-ize.txt
 65d9f69aaa86aaf841689e130983ea0a6abd53fd  node_modules/@cspell/dict-en-shared/dict/shared-additional-words.txt
 6bf4af0506c5a2d458daf822db58c28a7b46df82  src/acronyms.txt

--- a/dictionaries/en_US/cspell-ext.json
+++ b/dictionaries/en_US/cspell-ext.json
@@ -54,7 +54,8 @@
                         "replace": 75
                     }
                 ]
-            }
+            },
+            "ignoreForbiddenWords": true
         }
     ],
     "dictionaries": [],

--- a/dictionaries/en_US/en_US.trie
+++ b/dictionaries/en_US/en_US.trie
@@ -6322,8 +6322,8 @@ h#1140;<p#1sgb;<so#9qe;<$$p$2
 y
 ch#2rg;<oon#13ha;<4g$i#ms;<k#et;<l#gkf;<mb#1dm;<pana$i\'#9;<c$e#9;<s#9q;<t#fgo;<$s$u#th;<y$$4pa#6h;<e\'#9;<
 a#781;<b#h52;<case$t#li5;<4d$f#m5f;<sc#1maf;<e#ken;<$wr#1sjn;<2$hog#fjc;<i#h8s;<n#1c;<o#6r;<u#9;<2u#qq;<2ica#ji6;<$e#fkn;<
-f#1fdb;<n#gv;<s#9q;<2o\'#9;<g#k4r;<l#1efr;<s$$w$$rannica#mck;<i#ltk;<$e#9;<s$z#iv1;<2os#n96;<u#hro;<2y#o;<2t#l;<3
-e#5va;<o\'#9;<c#kdf;<sin#1hus;<2$t#1u5u;<$2t#5rn;<2
+f#1fdb;<n#gv;<s#9q;<2o\'#9;<g#k4r;<l#1efr;<s$$$rannica#mck;<i#ltk;<$e#9;<s$z#iv1;<2os#n96;<u#hro;<2y#o;<2t#l;<3e#5va;<
+o\'#9;<c#kdf;<sin#1hus;<2$t#1u5u;<$2t#5rn;<2
 z
 ard#khd;<ev#hp7;<2i#21if;<s$$tz#26t;<3et#tgu;<2ig#4vl;<m#9r3;<tz#6v;<3u#dli;<2
 $

--- a/dictionaries/en_shared/dict/exclude-words.txt
+++ b/dictionaries/en_shared/dict/exclude-words.txt
@@ -4,4 +4,5 @@
 colum
 knifes
 midwifes
+typw
 ~colum

--- a/dictionaries/en_shared/src/exclude-words.txt
+++ b/dictionaries/en_shared/src/exclude-words.txt
@@ -1,4 +1,11 @@
+# This file is a list of words that should not be included in the dictionary.
+#
+# cspell:locale en
+#
+# Tell cspell to not spell check the misspelled words:
+# cspell:ignoreRegExp /^.*?(#|$)/gmu
 ~colum
 colum
 knifes
 midwifes
+typw # this is an abbreviation for "typewriter", but a common misspelling of "type". See: https://github.com/streetsidesoftware/cspell-dicts/discussions/4773


### PR DESCRIPTION

<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: English

## Description

Related to #4773

Since `typw` is a common misspelling of `type` and [not common](https://books.google.com/ngrams/graph?content=typw%2C+overmorrow&year_start=2000&year_end=2022&corpus=en&smoothing=3), I think it is worth it to not include `typw` in the default English dictionary. If someone needs it, they can always add it to their own dictionary.

## Checklist

- [ ] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [ ] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
