### PR TITLE
fix: add `pyrefly` to `python`

### DIFF
--- a/dictionaries/python/dict/python.txt
+++ b/dictionaries/python/dict/python.txt
@@ -7396,6 +7396,7 @@ pyqt5-qt5
 pyqt5-sip
 pyquery
 pyreadline
+pyrefly
 pyrfc
 pyright
 pyroaring

--- a/dictionaries/python/src/python/python.txt
+++ b/dictionaries/python/src/python/python.txt
@@ -638,6 +638,7 @@ pylint
 pypi
 pyproject
 pypy
+pyrefly
 pyright
 pytest
 PYTHONHOME


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: add word pyrefly to python'
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: python

## Description

Added `pyrefly`. Pyrefly is a type checker developed by Meta.

## References

<https://pyrefly.org/>

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
