### PR TITLE
fix: add `Nushell` to `software-tools`

### DIFF
--- a/dictionaries/software-terms/dict/software-tools.txt
+++ b/dictionaries/software-terms/dict/software-tools.txt
@@ -138,6 +138,7 @@ NestJS
 NetBSD
 Netlify
 New
+Nushell
 OSMC
 OXSecurity
 Octicons

--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -270,6 +270,7 @@ npx
 NRIA
 nuPlan
 nuScenes
+Nushell
 Octicons
 octokit
 oh-my-zsh


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: `software-tools`

## Description

Added `Nushell`, Nushell is a new type of shell.

## References

- <https://www.nushell.sh/>

## Checklist

- [x] By submitting this pull-request, you agree to follow our
      [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a
    dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
