### PR TITLE
fix: Remove "strate" from the US dict.

### DIFF
--- a/dictionaries/en_US/src/legacy/en_US.txt
+++ b/dictionaries/en_US/src/legacy/en_US.txt
@@ -19320,7 +19320,6 @@ strangered
 stranglings
 strangulations
 stratas
-strate
 stratifications
 stratocumuli
 stratous


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: en_US

## Description

This PR removes the word `strate` from `dictionaries/en_US/src/legacy/en_US.txt`.

The change aligns with modern US English, where the term is missing from major dictionaries and appears only as an Old English or historical variant (see the Oxford English Dictionary entry).

It also prevents false negatives when the French word `strate` (“layer”) appears in English text, ensuring CSpell flags it as an error.

## References

- https://www.oed.com/search/dictionary/?scope=Entries&q=strate
- https://www.merriam-webster.com/dictionary/strate
- https://www.collinsdictionary.com/us/spellcheck/english?q=strate
- https://dictionary.cambridge.org/spellcheck/english/?q=strate

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
