### PR TITLE
chore: fix cross-dictionary dependency issues when updating software terms.

### DIFF
--- a/dictionaries/en-common-misspellings/cspell.json
+++ b/dictionaries/en-common-misspellings/cspell.json
@@ -9,5 +9,5 @@
         "waivable"
     ],
     "ignorePaths": ["cspell*.json", "CHANGELOG.md", "dict", "**/*.csv", "src/fromCrateTypos/*.yaml"],
-    "import": ["./cspell-ext.json", "../en_GB/cspell-ext.json"],
+    "import": ["./cspell-ext.json", "../en_GB/cspell-ext.json", "../software-terms/cspell-ext.json" ],
 }


### PR DESCRIPTION

## Description

Make sure to include the latest software terms dictionary when spell checking en-common-misspellings


## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
