### PR TITLE
fix: Add multilog

### DIFF
--- a/dictionaries/software-terms/dict/softwareTerms.txt
+++ b/dictionaries/software-terms/dict/softwareTerms.txt
@@ -1766,9 +1766,9 @@ msgs
 msgstr
 mtime
 mtls
+multiLog
 multiPath
 multicast
-multilog
 multipass
 multiprocessing
 multiprop

--- a/dictionaries/software-terms/src/coding-terms.txt
+++ b/dictionaries/software-terms/src/coding-terms.txt
@@ -488,6 +488,7 @@ msgid
 msgList
 msgstr
 MSSQLSERVER
+multiLog
 multipass
 multiPath
 multitouch
@@ -943,4 +944,3 @@ zMax
 zMin
 zPos
 zVal
-multiLog


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: dictionaries/software-terms/src/coding-terms.txt

## Description

`multiple logs` may be spelled as `multilog` in coding.

## References

- https://manpages.debian.org/stretch/daemontools/multilog.8.en.html

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
