### PR TITLE
chore: add reference to word list generation script repo

### DIFF
--- a/dictionaries/gdscript/src/README.md
+++ b/dictionaries/gdscript/src/README.md
@@ -3,5 +3,7 @@
 All source files used to generate the dictionary should be stored in this directory.
 
 Main word list `gdscript-words/gdscript.txt` is generated from Godot
-documentation and should not be modified manually. Instead, any additional words
-should be added to `gdscript.txt`.
+documentation using a script from
+[mnemotic/gdscript-words](https://github.com/mnemotic/gdscript-words) (see
+`gdscript-words/README.md`) and should not be modified manually. Instead, any
+additional words should be added to `gdscript.txt`.


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: GDScript

## Description

Add a reference to the repo with word list generation script to the README, as suggested in #5041.

## Checklist

- [X] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [X] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
