### PR TITLE
fix: Add HTML attribute names to CSS dictionary

### DIFF
--- a/dictionaries/css/dict/css.txt
+++ b/dictionaries/css/dict/css.txt
@@ -22,6 +22,7 @@ Hz
 abbr
 abegede
 absolute
+accesskey
 action
 active
 add
@@ -73,6 +74,8 @@ attribute
 audio
 aural
 auto
+autocapitalize
+autofocus
 available
 avoid
 azimuth
@@ -202,6 +205,7 @@ constant
 contain
 container
 content
+contenteditable
 contents
 continue
 contrast
@@ -319,6 +323,7 @@ edge
 edges
 effect
 element
+elementtiming
 elevation
 ellipsis
 em
@@ -331,6 +336,7 @@ enabled
 encoding
 end
 endCaptures
+enterkeyhint
 entity
 erb
 escape
@@ -344,6 +350,7 @@ ex
 exact
 exclude
 exclusion
+exportparts
 extended
 extends
 face
@@ -351,6 +358,7 @@ fade
 fallback
 family
 feature
+fetchpriority
 fieldset
 figcaption
 figure
@@ -379,8 +387,13 @@ footer
 force
 forestgreen
 form
+formaction
 formal
 format
+formenctype
+formmethod
+formnovalidate
+formtarget
 forward
 forwards
 fr
@@ -482,6 +495,7 @@ ink
 inline
 inner
 input
+inputmode
 ins
 inset
 inside
@@ -499,7 +513,11 @@ isolate
 isolation
 italic
 item
+itemprop
+itemref
 items
+itemscope
+itemtype
 iteration
 ivory
 japanese
@@ -612,6 +630,7 @@ max
 maximize
 maximized
 maximum
+maxlength
 medi
 media
 medium
@@ -646,6 +665,7 @@ midnightblue
 min
 minimize
 minimum
+minlength
 minmax
 mintcream
 misc
@@ -1027,6 +1047,7 @@ t
 tab
 tab-scroll-arrow-back
 tab-scroll-arrow-forward
+tabindex
 table
 tabpanels
 tag
@@ -1166,6 +1187,7 @@ words
 wrap
 write
 writing
+writingsuggestions
 www
 x
 xml

--- a/dictionaries/css/src/css.txt
+++ b/dictionaries/css/src/css.txt
@@ -332,8 +332,8 @@ enabled
 encoding
 end
 endCaptures
-entity
 enterkeyhint
+entity
 erb
 escape
 eszett
@@ -346,9 +346,9 @@ ex
 exact
 exclude
 exclusion
+exportparts
 extended
 extends
-exportparts
 face
 fade
 fallback
@@ -383,9 +383,9 @@ footer
 force
 forestgreen
 form
+formaction
 formal
 format
-formaction
 formenctype
 formmethod
 formnovalidate
@@ -512,9 +512,9 @@ italic
 item
 itemprop
 itemref
+items
 itemscope
 itemtype
-items
 iteration
 ivory
 japanese
@@ -1044,9 +1044,9 @@ t
 tab
 tab-scroll-arrow-back
 tab-scroll-arrow-forward
+tabindex
 table
 tabpanels
-tabindex
 tag
 tahoma
 tamil


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: css

## Description

When using CSS attribute selectors such as `[contenteditable="true"]`, `[tabindex]`, or `input[maxlength="10"]`, the HTML attribute names inside the selectors may be flagged as spelling errors because they are not currently included in the CSS dictionary.

The following HTML attribute names were added to `dictionaries/css/src/css.txt` in alphabetical order:

### HTML global attributes
- `accesskey` - Specifies a keyboard shortcut to focus/activate an element 
- `autocapitalize` - Controls automatic capitalization behavior on mobile devices 
- `autofocus` - Automatically focuses the element when the page loads 
- `contenteditable` - Indicates whether the element's content is editable 
- `enterkeyhint` - Provides a hint about the action label for the Enter key 
- `exportparts` - Used in Shadow DOM to export shadow parts 
- `inputmode` - Hints at the type of data expected for virtual keyboard 
- `itemprop` - Microdata property name 
- `itemref` - References elements that provide additional microdata properties 
- `itemscope` - Creates a microdata item 
- `itemtype` - Specifies the URL of the microdata vocabulary 
- `tabindex` - Specifies the tab order of elements 
- `writingsuggestions` - Controls writing suggestions behavior

#### Why isn't `virtualkeyboardpolicy` added?: 

Because it's in experimental state.

### Other attributes
- `elementtiming` - Marks elements for Element Timing API observation 
- `fetchpriority` - Provides a hint about the relative priority for fetching 
- `maxlength` - Maximum number of characters allowed in input 
- `minlength` - Minimum number of characters required in input 
- `formaction` - Specifies the URL for form submission 
- `formenctype` - Specifies encoding type for form submission 
- `formmethod` - Specifies HTTP method for form submission 
- `formnovalidate` - Bypasses form validation on submission 
- `formtarget` - Specifies target for form submission result

### Result

These additions allow attribute selectors such as the following to be used without triggering spell-check warnings:

```css
[contenteditable="true"] { outline: 2px solid blue; }
[tabindex]:focus { border: 1px solid red; }
input[maxlength] { border-color: orange; }
[itemprop="name"] { font-weight: bold; }
```

## References

- https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes
- https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes
- https://html.spec.whatwg.org/multipage/

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - fix: - for minor changes like adding words or fixing spelling issues.
  - feat: - for a significant change like adding a whole new set of words to a dictionary.
  - feat!: - for breaking changes, like file format or licensing changes.
  - chore: - for changes that do not impact the content of dictionaries.
