### PR TITLE
chore: add file for npmjs imports

### DIFF
--- a/dictionaries/npm/cspell-tools.config.yaml
+++ b/dictionaries/npm/cspell-tools.config.yaml
@@ -14,4 +14,5 @@ targets:
           - ../software-terms/dict/softwareTerms.txt
       - src/npm-keywords.txt
       - src/tools.txt
+      - src/imports.txt
     sort: true

--- a/dictionaries/npm/src/imports.txt
+++ b/dictionaries/npm/src/imports.txt
@@ -1,0 +1,3 @@
+# This file is a list of module imports
+# It is a stop-gap solution until a parser is in place.
+# The words below are added to the dictionary.


### PR DESCRIPTION

<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: npm

## Description

The import is to be able to explicitly specify npmjs imports. This is to handle the case were the package name and the imports do not match.

- add `npm/src/imports.txt`


## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
