### PR TITLE
fix: add missing file extensions

### DIFF
--- a/dictionaries/filetypes/src/filetypes.txt
+++ b/dictionaries/filetypes/src/filetypes.txt
@@ -99,6 +99,7 @@ exe
 eyaml
 eyml
 fish
+flac
 flv
 fs
 fsharp
@@ -339,6 +340,7 @@ vstx
 vue
 wav
 wbk
+weba
 webm
 webmanifest
 wks


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: filetypes

## Description

Add `flac` and `weba` extensions

## References

- [flac](https://en.wikipedia.org/wiki/FLAC)
- [weba](https://fileextension.fandom.com/wiki/WEBA)

## Checklist

- [X] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [X] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.

Closes #5274