### PR TITLE
ci: prevent automation workflows from running on forks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   publish:
+    if: github.repository_owner == 'streetsidesoftware'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   release-please:
+    if: github.repository_owner == 'streetsidesoftware'
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/update-dependabot.yml
+++ b/.github/workflows/update-dependabot.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   update-dependabot:
+    if: github.repository_owner == 'streetsidesoftware'
     runs-on: ubuntu-latest
     env:
       NEW_BRANCH: update-dependabot-${{ inputs.base || 'main' }}


### PR DESCRIPTION
> [!NOTE]
> This PR was co-authored with [Claude Code](https://claude.com/claude-code).

# Add/Fix Dictionary

Dictionary: _N/A — this is a CI change_

## Description

Some GitHub Actions workflows were running on forks of this repository. After some period of inactivity, fork owners receive emails like _"[GitHub] The "🔗 Update Dependencies Main" workflow in andyw8/cspell-dicts will be disabled soon"_.

This adds `if: github.repository_owner == 'streetsidesoftware'` to the job condition in the three workflows that were missing it:

- `update-dependabot.yml`
- `release-please.yml`
- `publish.yml`

The other automation workflows (`update-dictionaries.yml`, `update-dependencies.yml`, `update-readme.yml`, `build-dictionaries.yml`) already had this guard. CI workflows (`lint`, `test`, `cspell-action`, `autofix`, `codeql`) are intentionally left without it so they continue to run on fork PRs.

## References

- N/A

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.