### PR TITLE
fix: add "invokable" to software-terms dictionary

### DIFF
--- a/dictionaries/software-terms/dict/softwareTerms.txt
+++ b/dictionaries/software-terms/dict/softwareTerms.txt
@@ -1479,6 +1479,7 @@ intervalObj
 invariant
 invariants
 invokable
+invokables
 iops
 iostream
 iowait
@@ -2901,6 +2902,8 @@ uninstallation
 uninstalling
 uninstantiatable
 uninstrumented
+uninvokable
+uninvokables
 uniq
 uniqueId
 uniqueIdentifier

--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -914,8 +914,6 @@ invariant
 invariants
 invokable
 invokables
-uninvokable
-uninvokables
 iops
 iowait
 ipaddress
@@ -2024,6 +2022,8 @@ uninitialize
 uninstall
 uninstallation
 uninstalling
+uninvokable
+uninvokables
 uniq
 uniquifier
 unit


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: software-terms

## Description

Agent (Claude) Skills for GitHub Copilot supports `user-invokable` property.

Note: "invo***c***able" seems to be more major.

## References

- https://en.wiktionary.org/wiki/invokable
- https://code.visualstudio.com/docs/copilot/customization/agent-skills#_header-required

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
