### PR TITLE
feat: Ignores URLs in CSS

### DIFF
--- a/dictionaries/css/cspell-ext.json
+++ b/dictionaries/css/cspell-ext.json
@@ -22,7 +22,7 @@
         {
             "name": "CSS-url",
             "pattern": "/\\burl\\((?:\"data:[^\"]*\"|'data:[^']*')\\)/gm"
-        },
+        }
     ],
     // Language Rules to apply to matching files.
     // Files are matched on `languageId` and `locale`
@@ -38,17 +38,13 @@
             // Adding patterns to the "includeRegExpList" to only include matching patterns
             "includeRegExpList": [],
             // To exclude patterns, add them to "ignoreRegExpList"
-            "ignoreRegExpList": [
-                "CSS-url"
-            ],
+            "ignoreRegExpList": ["CSS-url"],
             // regex patterns than can be used with ignoreRegExpList or includeRegExpList
             // Example: "pattern": [{ "name": "mdash", "pattern": "&mdash;" }]
             // This could be included in "ignoreRegExpList": ["mdash"]
             "patterns": [],
             // List of dictionaries to enable by name in `dictionaryDefinitions`
-            "dictionaries": [
-                "css"
-            ],
+            "dictionaries": ["css"],
             // Dictionary definitions can also be supplied here. They are only used iff "languageId" and "locale" match.
             "dictionaryDefinitions": []
         }


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: CSS

## Description

Ignores URLs in CSS

## References

https://github.com/streetsidesoftware/cspell-dicts/discussions/5303

## Checklist

- [X] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [X] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
