### PR TITLE
fix: Add '.ipynb' to filetypes dictionary

### DIFF
--- a/dictionaries/filetypes/src/filetypes.txt
+++ b/dictionaries/filetypes/src/filetypes.txt
@@ -151,6 +151,7 @@ ini
 inl
 ino
 install
+ipynb
 isml
 iso
 jade


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding .ipynb to the filetypes dictionary
title: 'fix: '
labels: dictionary
--->

# Fix Dictionary

Dictionary: filetypes

## Description
Added `.ipynb` to the filetypes dictionary.

An .ipynb file is a Jupyter Notebook, commonly used in data science.

## References

- [Jupyter homepage](https://jupyter.org/about)

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.