### PR TITLE
feat: Add software-terms-alternative dictionary

### DIFF
--- a/dictionaries/software-terms/cspell-ext.json
+++ b/dictionaries/software-terms/cspell-ext.json
@@ -8,7 +8,7 @@
         {
             // changing the name is a breaking change.
             "name": "softwareTerms",
-            "path": "./dict/softwareTerms.txt",
+            "path": "./dict/softwareTerms.txt.gz",
             "description": "Software terms dictionary."
         },
         {
@@ -40,6 +40,11 @@
             "name": "coding-compound-terms",
             "path": "./dict/coding-compound-terms.txt",
             "description": "Common coding compound terms."
+        },
+        {
+            "name": "software-terms-alternative",
+            "path": "./dict/software-terms-alternative.txt",
+            "description": "Alternative software terms dictionary."
         }
     ],
     // Enable `softwareTerms` by default if this extension is imported.

--- a/dictionaries/software-terms/cspell-tools.config.yaml
+++ b/dictionaries/software-terms/cspell-tools.config.yaml
@@ -14,7 +14,8 @@ targets:
     format: plaintext
     targetDirectory: './dict'
     generateNonStrict: false
-    compress: false
+    compress: true
+    keepUncompressed: true
   - name: 'software-tools'
     sources:
       - filename: src/software-tools.txt
@@ -56,3 +57,12 @@ targets:
     targetDirectory: './dict'
     generateNonStrict: false
     compress: false
+  - name: 'software-terms-alternative'
+    sources:
+      - filename: src/software-terms-alternative.txt
+        split: true
+    format: plaintext
+    targetDirectory: './dict'
+    generateNonStrict: false
+    compress: false
+    keepUncompressed: true

--- a/dictionaries/software-terms/dict/software-terms-alternative.txt
+++ b/dictionaries/software-terms/dict/software-terms-alternative.txt
@@ -1,0 +1,4 @@
+
+# cspell-tools: keep-case no-split
+
+invokable

--- a/dictionaries/software-terms/package.json
+++ b/dictionaries/software-terms/package.json
@@ -34,6 +34,7 @@
   "files": [
     "dict/*",
     "!dict/README.md",
+    "!dict/softwareTerms.txt",
     "cspell-corrections.yaml",
     "cspell-ext.json"
   ],

--- a/dictionaries/software-terms/src/software-terms-alternative.txt
+++ b/dictionaries/software-terms/src/software-terms-alternative.txt
@@ -1,0 +1,5 @@
+# This file contains alternative spellings that are not enabled by default.
+# They may be uncommon terms or discouraged spellings.
+#
+# cspell:dictionaries software-terms-alternative
+invokable


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _software-terms_

## Description

Add a new dictionary to support alternative spellings for some software terms. It will be included with `cspell`, but not enabled by default.

## References

- https://github.com/streetsidesoftware/cspell-dicts/pull/5317#issuecomment-3988035353

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
