### PR TITLE
chore: change build-dictionaries branch to be `build-dictionaries`

### DIFF
--- a/.github/workflows/build-dictionaries.yml
+++ b/.github/workflows/build-dictionaries.yml
@@ -13,7 +13,7 @@ on:
       new-branch:
         description: 'PR Branch to create'
         type: string
-        default: update-dictionaries
+        default: build-dictionaries
         required: false
 
 permissions:


### PR DESCRIPTION
There was a conflict with the update-dictionaries workflow branch.

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
