### PR TITLE
fix: add autospace to css dictionary

### DIFF
--- a/dictionaries/css/dict/css.txt
+++ b/dictionaries/css/dict/css.txt
@@ -76,6 +76,7 @@ aural
 auto
 autocapitalize
 autofocus
+autospace
 available
 avoid
 azimuth

--- a/dictionaries/css/src/css.txt
+++ b/dictionaries/css/src/css.txt
@@ -71,6 +71,7 @@ aural
 auto
 autocapitalize
 autofocus
+autospace
 available
 avoid
 azimuth


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: `css`

## Description

Adds `autospace` to the CSS dictionary so `text-autospace` no longer produces a false positive.

- **Dictionary update**
  - add `autospace` to the CSS source word list
  - regenerate the compiled CSS dictionary output

- **Affected case**
  ```css
  :root {
    text-autospace: normal;
  }

  pre, code, samp, kbd {
    text-autospace: no-autospace;
  }
  ```

Log:

- https://github.com/tats-u/cspell-dicts/sessions/ee4eb954-0846-455c-82f2-6e16734eda36 (my prompt is in Japanese; translate it into your native language using your favorite translator)
- https://github.com/tats-u/cspell-dicts/pull/2

## References

- https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-autospace
- https://developer.chrome.com/blog/css-i18n-features#inter-script_spacing_text-autospace
- https://drafts.csswg.org/css-text-4/#propdef-text-autospace

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.

