### PR TITLE
fix: Add Kubernetes resources and third-party CRD terms

### DIFF
--- a/dictionaries/k8s/dict/k8s.txt
+++ b/dictionaries/k8s/dict/k8s.txt
@@ -3,12 +3,15 @@
 
 $ref
 $schema
+Dynakube
 HPA
 KubeProxyConfiguration
+Overprovisioning
 Port
 StatefulSet
 StatefulSets
 VPA
+aadpodidentity
 acceptedNames
 accessModes
 acquireTime
@@ -24,8 +27,12 @@ address
 addressType
 addresses
 admissionReviewVersions
+admissionregistration
 affinity
 aggregationRule
+alertingrules
+alertmanagerconfigs
+alertmanagers
 allOf
 allocatable
 allocateLoadBalancerNodePorts
@@ -44,6 +51,10 @@ apiServerID
 apiVersion
 apiVersions
 apiextensions
+apiregistration
+apiserver
+apiservers
+apiservices
 appProtocol
 applySet
 architecture
@@ -60,6 +71,7 @@ audiences
 authenticated
 automanaged
 automountServiceAccountToken
+autoscalers
 availableOnNodes
 availableReplicas
 averageUtilization
@@ -67,6 +79,7 @@ averageValue
 awsElasticBlockStore
 azureDisk
 azureFile
+azurekeyvaultsecretsprovider
 backend
 backoffLimit
 behavior
@@ -135,6 +148,7 @@ controllerPublishSecretRef
 conversion
 conversionReviewVersions
 count
+crds
 creationTimestamp
 csi
 current
@@ -145,6 +159,7 @@ currentNumberScheduled
 currentReplicas
 currentRevision
 daemonEndpoints
+daemonset
 data
 dataSource
 dataSourceRef
@@ -186,6 +201,7 @@ distinguisherMethod
 divisor
 dnsConfig
 dnsPolicy
+dockercfg
 downwardAPI
 driver
 driverName
@@ -276,8 +292,10 @@ handSize
 handler
 hard
 healthCheckNodePort
+healthz
 hints
 holderIdentity
+horizontalpodautoscalers
 host
 hostAliases
 hostIP
@@ -306,6 +324,7 @@ incomplete
 ingress
 ingressClass
 ingressClassName
+ingressclasses
 initContainerStatuses
 initContainers
 initialDelaySeconds
@@ -342,6 +361,7 @@ kubeletConfigKey
 kubeletEndpoint
 kubeletVersion
 kubelets
+kubepods
 kubernetes
 kustomization
 labelSelector
@@ -428,6 +448,7 @@ namespace
 namespaceSelector
 namespaced
 namespaces
+networkpolicies
 nfs
 nodeAffinity
 nodeAffinityPolicy
@@ -496,6 +517,7 @@ persistentVolumeClaimRetentionPolicy
 persistentVolumeClaims
 persistentVolumeName
 persistentVolumeReclaimPolicy
+persistentvolumes
 phase
 photonPersistentDisk
 platform
@@ -513,6 +535,8 @@ podInfoOnMount
 podManagementPolicy
 podSelector
 poddisruptionbudget
+poddisruptionbudgets
+podmonitors
 pods
 policies
 policyName
@@ -543,6 +567,9 @@ privileged
 procMount
 progressDeadlineSeconds
 projected
+prometheusagents
+prometheuses
+prometheusrules
 propagationPolicy
 properties
 protectionDomain
@@ -623,6 +650,9 @@ scaleDown
 scaleIO
 scaleTargetRef
 scaleUp
+scaledjobs
+scaledobject
+scaledobjects
 schedulable
 schedule
 schedulerName
@@ -634,6 +664,7 @@ scope
 scopeName
 scopeSelector
 scopes
+scrapeconfigs
 seLinuxMount
 seLinuxOptions
 searches
@@ -645,6 +676,7 @@ secretKeyRef
 secretName
 secretNamespace
 secretRef
+secretproviderclass
 secrets
 securityContext
 selectPolicy
@@ -661,6 +693,7 @@ serviceAccount
 serviceAccountName
 serviceAccountToken
 serviceName
+servicemonitors
 serving
 sessionAffinity
 sessionAffinityConfig
@@ -703,6 +736,7 @@ storagePolicyName
 storagePool
 storageVersionHash
 storageVersions
+storageclasses
 storageos
 storedVersions
 strategy
@@ -739,6 +773,7 @@ terminating
 terminationGracePeriodSeconds
 terminationMessagePath
 terminationMessagePolicy
+thanosrulers
 time
 timeAdded
 timeZone
@@ -783,6 +818,11 @@ verbs
 version
 versionPriority
 versions
+vmalert
+vmalerts
+vmauth
+vmuser
+vmusers
 volume
 volumeAttributes
 volumeBindingMode
@@ -797,6 +837,7 @@ volumeMounts
 volumeName
 volumeNamespace
 volumePath
+volumeattachments
 volumes
 volumesAttached
 volumesInUse

--- a/dictionaries/k8s/src/k8s.txt
+++ b/dictionaries/k8s/src/k8s.txt
@@ -1,5 +1,6 @@
 $ref
 $schema
+aadpodidentity
 acceptedNames
 accessModes
 acquireTime
@@ -14,9 +15,13 @@ addonmanager
 address
 addresses
 addressType
+admissionregistration
 admissionReviewVersions
 affinity
 aggregationRule
+alertingrules
+alertmanagerconfigs
+alertmanagers
 allocatable
 allocatedResources
 allocateLoadBalancerNodePorts
@@ -32,7 +37,11 @@ anyOf
 apiextensions
 apiGroup
 apiGroups
+apiregistration
+apiserver
 apiServerID
+apiservers
+apiservices
 apiVersion
 apiVersions
 applySet
@@ -51,6 +60,7 @@ audiences
 authenticated
 automanaged
 automountServiceAccountToken
+autoscalers
 availableOnNodes
 availableReplicas
 averageUtilization
@@ -58,6 +68,7 @@ averageValue
 awsElasticBlockStore
 azureDisk
 azureFile
+azurekeyvaultsecretsprovider
 backend
 backoffLimit
 behavior
@@ -126,6 +137,7 @@ controllerPublishSecretRef
 conversion
 conversionReviewVersions
 count
+crds
 creationTimestamp
 csi
 current
@@ -136,6 +148,7 @@ currentNumberScheduled
 currentReplicas
 currentRevision
 daemonEndpoints
+daemonset
 data
 datasetName
 datasetUUID
@@ -177,12 +190,14 @@ distinguisherMethod
 divisor
 dnsConfig
 dnsPolicy
+dockercfg
 downwardAPI
 driver
 driverName
 drivers
 drop
 dryRun
+Dynakube
 effect
 egress
 emptyDir
@@ -267,8 +282,10 @@ handler
 handSize
 hard
 healthCheckNodePort
+healthz
 hints
 holderIdentity
+horizontalpodautoscalers
 host
 hostAliases
 hostIP
@@ -297,6 +314,7 @@ immutable
 incomplete
 ingress
 ingressClass
+ingressclasses
 ingressClassName
 initContainers
 initContainerStatuses
@@ -333,6 +351,7 @@ kubeletConfigKey
 kubeletEndpoint
 kubelets
 kubeletVersion
+kubepods
 KubeProxyConfiguration
 kubeProxyVersion
 kubernetes
@@ -421,6 +440,7 @@ namespace
 namespaced
 namespaces
 namespaceSelector
+networkpolicies
 nfs
 nodeAffinity
 nodeAffinityPolicy
@@ -467,6 +487,7 @@ orphanDependents
 os
 osImage
 overhead
+Overprovisioning
 ownerReferences
 parallelism
 parameters
@@ -489,6 +510,7 @@ persistentVolumeClaimRetentionPolicy
 persistentVolumeClaims
 persistentVolumeName
 persistentVolumeReclaimPolicy
+persistentvolumes
 phase
 photonPersistentDisk
 platform
@@ -499,12 +521,14 @@ podAntiAffinity
 podCIDR
 podCIDRs
 poddisruptionbudget
+poddisruptionbudgets
 podFailurePolicy
 podFixed
 podInfoOnMount
 podIP
 podIPs
 podManagementPolicy
+podmonitors
 pods
 podSelector
 policies
@@ -537,6 +561,9 @@ privileged
 procMount
 progressDeadlineSeconds
 projected
+prometheusagents
+prometheuses
+prometheusrules
 propagationPolicy
 properties
 protectionDomain
@@ -613,6 +640,9 @@ runAsUserName
 running
 runtimeClassName
 scale
+scaledjobs
+scaledobject
+scaledobjects
 scaleDown
 scaleIO
 scaleTargetRef
@@ -628,6 +658,7 @@ scope
 scopeName
 scopes
 scopeSelector
+scrapeconfigs
 searches
 seccomp
 seccompProfile
@@ -636,6 +667,7 @@ secretFile
 secretKeyRef
 secretName
 secretNamespace
+secretproviderclass
 secretRef
 secrets
 securityContext
@@ -654,6 +686,7 @@ service
 serviceAccount
 serviceAccountName
 serviceAccountToken
+servicemonitors
 serviceName
 serving
 sessionAffinity
@@ -692,6 +725,7 @@ stdinOnce
 storage
 storageCapacity
 storageClass
+storageclasses
 storageClassName
 storageMode
 storageos
@@ -735,6 +769,7 @@ terminating
 terminationGracePeriodSeconds
 terminationMessagePath
 terminationMessagePolicy
+thanosrulers
 time
 timeAdded
 timeoutSeconds
@@ -779,7 +814,13 @@ verbs
 version
 versionPriority
 versions
+vmalert
+vmalerts
+vmauth
+vmuser
+vmusers
 volume
+volumeattachments
 volumeAttributes
 volumeBindingMode
 volumeClaimTemplate


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _k8s_

## Description

Extend the `k8s` dictionary with terms that regularly appear in `kubectl` output, RBAC rules and Kubernetes manifests, but are currently flagged as unknown by cspell.

### Kubernetes API resource names (plural / lowercase forms)

Most singular / camelCase forms are already present (e.g. `persistentVolumeClaim`, `storageClass`, `ingressClass`, `poddisruptionbudget`). This adds the plural lowercase forms returned by `kubectl api-resources` and used in RBAC `resources:` lists:

- `apiserver`, `apiservers`: kube-apiserver control-plane component
- `apiservices`: `APIService` resource (aggregation layer)
- `apiregistration`: API group `apiregistration.k8s.io`
- `admissionregistration`: API group `admissionregistration.k8s.io`
- `autoscalers`: generic plural for HPA/VPA/CA resources
- `crds`: shorthand for CustomResourceDefinitions (`kubectl get crds`)
- `daemonset`: workload resource (`kind: DaemonSet`)
- `dockercfg`: Secret type `kubernetes.io/dockercfg`
- `healthz`: convention for Kubernetes health-probe endpoints
- `horizontalpodautoscalers`: HPA plural resource
- `ingressclasses`: `IngressClass` plural resource
- `kubepods`: cgroup slice name created by kubelet (`kubepods.slice`)
- `networkpolicies`: `NetworkPolicy` plural resource
- `persistentvolumes`: `PersistentVolume` plural resource
- `poddisruptionbudgets`: `PodDisruptionBudget` plural resource
- `storageclasses`: `StorageClass` plural resource
- `volumeattachments`: `VolumeAttachment` plural resource

### Prometheus Operator CRDs (`monitoring.coreos.com`)

CRD names used across Prometheus / Alertmanager / Thanos manifests:

- `alertmanagerconfigs`: `AlertmanagerConfig` CRD
- `alertmanagers`: `Alertmanager` CRD (plural)
- `podmonitors`: `PodMonitor` CRD
- `prometheusagents`: `PrometheusAgent` CRD (agent mode)
- `prometheuses`: `Prometheus` CRD (plural)
- `prometheusrules`: `PrometheusRule` CRD
- `scrapeconfigs`: `ScrapeConfig` CRD
- `servicemonitors`: `ServiceMonitor` CRD
- `thanosrulers`: `ThanosRuler` CRD

### Grafana Loki Operator CRDs (`loki.grafana.com`)

- `alertingrules`: `AlertingRule` CRD (also used by Grafana Mimir/Cortex Ruler tooling)

### VictoriaMetrics Operator CRDs (`operator.victoriametrics.com`)

- `vmalert`, `vmalerts`: `VMAlert` CRD (rule evaluation component)
- `vmauth`: `VMAuth` CRD (auth/proxy)
- `vmuser`, `vmusers`: `VMUser` CRD (VMAuth user)

### KEDA CRDs (`keda.sh`)

- `scaledjobs`: `ScaledJob` CRD
- `scaledobject`, `scaledobjects`: `ScaledObject` CRD

### Other third-party Kubernetes CRDs and add-ons

- `Dynakube`: `DynaKube` CRD kind from Dynatrace Operator
- `secretproviderclass`: Secrets Store CSI Driver CRD
- `azurekeyvaultsecretsprovider`: Azure Key Vault Secrets Provider AKS add-on
- `aadpodidentity`: legacy AAD Pod Identity project (deprecated in favour of Azure Workload Identity)
- `Overprovisioning`: Cluster Autoscaler over-provisioning pattern (Deployment and PriorityClass naming convention)

## References

- Kubernetes API Concepts: https://kubernetes.io/docs/reference/using-api/
- Prometheus Operator API: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md
- Grafana Loki Operator: https://loki-operator.dev/
- VictoriaMetrics Operator: https://docs.victoriametrics.com/operator/
- KEDA: https://keda.sh/
- Dynatrace Operator: https://github.com/Dynatrace/dynatrace-operator
- Secrets Store CSI Driver: https://secrets-store-csi-driver.sigs.k8s.io/

## Checklist

- [X] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [X] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
