### PR TITLE
fix: Add Azure and Packer identifiers to Terraform dictionary

### DIFF
--- a/dictionaries/companies/dict/companies.txt
+++ b/dictionaries/companies/dict/companies.txt
@@ -8,6 +8,7 @@ AAA
 AAPL
 ABB
 ABBV
+ABBYY
 ABIOMED
 ABMD
 ACFS
@@ -226,6 +227,7 @@ Bandung
 Bangalore
 Bank
 Bankengruppe
+Bankin
 Banking
 Banks
 Baosteel
@@ -274,6 +276,7 @@ Biogen
 Biomet
 Birmingham
 Bitly
+Bitnami
 Bjango
 Black
 BlackRock
@@ -282,6 +285,7 @@ Blizzard
 Bloomberg
 Bloomreach
 Bluesky
+Blueway
 Boeing
 Bologna
 Bombay
@@ -664,6 +668,7 @@ Electricite
 Electronic
 Electronics
 Eleuther
+Elfsight
 Eli
 Emerson
 Emojipedia
@@ -821,6 +826,7 @@ Georgetown
 Georgia
 Ghent
 Gilead
+Giphy
 GitHub
 GitLab
 Glasgow
@@ -940,6 +946,7 @@ Huadian
 Huaneng
 Huawei
 Huazhong
+HubSpot
 Hughes
 Hulu
 Humana
@@ -1182,6 +1189,7 @@ Leucadia
 Leuven
 Level
 Levis
+LexisNexis
 Lexus
 Liatrio
 Liberapay
@@ -1821,6 +1829,7 @@ Sekiyu
 Semilux
 Semmle
 Sempra
+Sencha
 Sensedia
 Seoul
 Service
@@ -1843,6 +1852,7 @@ Shougang
 Showa
 Side
 Siemens
+Silae
 Silicom
 Simon
 Singapore
@@ -1857,6 +1867,7 @@ Skaffold
 Skoda
 Skyworks
 Slevomat
+Slimpay
 Smania
 Smarkets
 Smarty
@@ -1912,6 +1923,7 @@ Statoil
 Steel
 Steelers
 Stellantis
+Stimulsoft
 Stockholm
 Storage
 Stores
@@ -2274,6 +2286,7 @@ Zions
 Zoetis
 Zoho
 Zscaler
+Zuora
 Zurich
 and
 arXiv

--- a/dictionaries/companies/src/companies.txt
+++ b/dictionaries/companies/src/companies.txt
@@ -900,6 +900,7 @@ HSBC Holdings
 HSIC
 Huawei Investment & Holding
 Huazhong University of Science and Technology
+HubSpot
 Hulu
 Humana
 Humana Inc.

--- a/dictionaries/terraform/checksum.txt
+++ b/dictionaries/terraform/checksum.txt
@@ -1,2 +1,2 @@
-14f8d1b3f9b82913b6ea3b88021f889956ddbfcd  dict/terraform.txt
-b8d921a6f909b8df6504c157104b1d700dded3fd  src/terraform.txt
+589d39d3a7cb292fce3b125366ebb78aede84b15  dict/terraform.txt
+183641fd27ef148f6769ade1a54f9f26a4ef3e47  src/terraform.txt

--- a/dictionaries/terraform/dict/terraform.txt
+++ b/dictionaries/terraform/dict/terraform.txt
@@ -3,10 +3,18 @@
 
 abs
 abspath
+acrpull
+agentpool
 alltrue
 anytrue
+appgateway
 automount
 azuread
+azuredevops
+azureidentity
+azurekms
+azureml
+azurepolicy
 chdir
 chomp
 chunklist
@@ -38,6 +46,7 @@ flatten
 format
 formatdate
 formatlist
+francecentral
 indent
 index
 issensitive
@@ -57,6 +66,7 @@ merge
 min
 parseint
 pathexpand
+pkrvars
 plantimestamp
 pow
 regexall
@@ -105,6 +115,7 @@ urlencode
 uuid
 uuidv5
 values
+westeurope
 yamldecode
 yamlencode
 zipmap

--- a/dictionaries/terraform/src/terraform.txt
+++ b/dictionaries/terraform/src/terraform.txt
@@ -1,9 +1,17 @@
 abs
 abspath
+acrpull
+agentpool
 alltrue
 anytrue
+appgateway
 automount
 azuread
+azuredevops
+azureidentity
+azurekms
+azureml
+azurepolicy
 chdir
 chomp
 chunklist
@@ -35,6 +43,7 @@ flatten
 format
 formatdate
 formatlist
+francecentral
 indent
 index
 issensitive
@@ -54,6 +63,7 @@ merge
 min
 parseint
 pathexpand
+pkrvars
 plantimestamp
 pow
 regexall
@@ -104,6 +114,7 @@ urlencode
 uuid
 uuidv5
 values
+westeurope
 yamldecode
 yamlencode
 zipmap


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _terraform_

## Description

Extend the `terraform` dictionary with Azure identifiers and the sibling Packer file extension. Follows the same pattern as `azuread` (already shipped in this dictionary): Azure provider / resource / role identifiers used in HCL, Bicep and ARM templates are collected here.

### Azure Terraform providers

- `azuredevops`: Terraform provider for Azure DevOps (`microsoft/azuredevops`)
- `azureidentity`: `identity` block identifier used with Azure managed identities (e.g. `azurerm_user_assigned_identity`)

### Azure resource identifiers

- `agentpool`: AKS node-pool identifier used in `azurerm_kubernetes_cluster` and `azurerm_kubernetes_cluster_node_pool` resource attributes
- `appgateway`: Azure Application Gateway shorthand (`azurerm_application_gateway`)
- `azurekms`: Kubernetes KMS provider identifier for the Azure Key Vault encryption provider (`--encryption-provider-config`)
- `azureml`: Azure Machine Learning workspace resource identifier (`azurerm_machine_learning_workspace`)
- `azurepolicy`: Azure Policy add-on identifier used in AKS resources

### Azure RBAC role names

- `acrpull`: Azure Container Registry `AcrPull` built-in role, commonly granted through `azurerm_role_assignment`

### Azure regions

- `francecentral`: Azure region identifier (Paris, France)
- `westeurope`: Azure region identifier (Amsterdam, Netherlands)

### Packer (HashiCorp sibling)

- `pkrvars`: Packer variables file extension (`.pkrvars.hcl`), the Packer equivalent of Terraform's `.tfvars`

## References

- Terraform Azure DevOps provider: https://registry.terraform.io/providers/microsoft/azuredevops
- Azure RBAC built-in roles: https://learn.microsoft.com/azure/role-based-access-control/built-in-roles
- Azure regions: https://azure.microsoft.com/global-infrastructure/geographies/
- Kubernetes KMS providers: https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/
- Packer variables: https://developer.hashicorp.com/packer/docs/templates/hcl_templates/variables

## Checklist

- [X] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [X] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
