### PR TITLE
fix: Add shared English words from #5523

### DIFF
--- a/dictionaries/en_shared/dict/shared-additional-words-ize.txt
+++ b/dictionaries/en_shared/dict/shared-additional-words-ize.txt
@@ -1,4 +1,5 @@
 
 # cspell-tools: keep-case no-split
 
+incentivized
 unsynchronized

--- a/dictionaries/en_shared/dict/shared-additional-words.txt
+++ b/dictionaries/en_shared/dict/shared-additional-words.txt
@@ -129,6 +129,7 @@ ludology
 marionnettes
 micellar
 minimalistic
+misattributed
 misattribution
 mitigations
 mukimame
@@ -203,6 +204,7 @@ unbundles
 unbundling
 unbundlings
 uncomfortability
+underdetermined
 underperform
 underperformance
 underperformances

--- a/dictionaries/en_shared/src/shared-additional-words-ize.txt
+++ b/dictionaries/en_shared/src/shared-additional-words-ize.txt
@@ -4,4 +4,5 @@
 # It avoids imposing "-ize" spellings on other English variants like en_CA, en_AU, or en_GB-ise
 #
 # cspell-tools: split
+incentivized
 unsynchronized

--- a/dictionaries/en_shared/src/shared-additional-words.txt
+++ b/dictionaries/en_shared/src/shared-additional-words.txt
@@ -229,3 +229,5 @@ wallaby
 wirelessly
 wombat
 wombats
+misattributed
+underdetermined

--- a/dictionaries/en_shared/src/shared-additional-words.txt
+++ b/dictionaries/en_shared/src/shared-additional-words.txt
@@ -125,6 +125,7 @@ ludology
 marionnettes
 micellar
 minimalistic
+misattributed
 misattribution
 mitigations
 mukimame
@@ -200,6 +201,7 @@ unbundles
 unbundling
 unbundlings
 uncomfortability
+underdetermined
 underperform
 underperformance
 underperformances
@@ -229,5 +231,3 @@ wallaby
 wirelessly
 wombat
 wombats
-misattributed
-underdetermined


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: English

## Description

This PR updates the **en_shared** English dictionary sources by adding a few additional shared words (including one “-ize” spelling) to reduce false positives across supported English variants.

**Changes:**
- Add `misattributed` and `underdetermined` to `shared-additional-words.txt`
- Add `incentivized` to `shared-additional-words-ize.txt`


## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
