### PR TITLE
fix: Add word betterleaksignore to software-terms dictionary

### DIFF
--- a/dictionaries/software-terms/dict/software-tools.txt
+++ b/dictionaries/software-terms/dict/software-tools.txt
@@ -303,6 +303,7 @@ avsc
 azurecli
 bantime
 betterem
+betterleaksignore
 bitnamicharts
 bittorrent
 blackduck

--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -49,6 +49,7 @@ Bazel
 Berkshelf
 betterem
 Betterleaks
+betterleaksignore
 Bitbucket
 bitnamicharts
 bittorrent


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _software-terms_ (file `software-tools.txt`)

## Description

Add `betterleaksignore` to the `software-terms` dictionary, so that the `.betterleaksignore` file name (used by Betterleaks to whitelist findings) is recognized by cspell.

This mirrors the existing entry `gitleaksignore` (for Gitleaks' companion file `.gitleaksignore`) that already ships in this dictionary right after `Gitleaks`. `betterleaksignore` is added right after `Betterleaks` (added in #5543) to keep the same convention.

## References

- Betterleaks: https://github.com/betterleaks/betterleaks
- Gitleaks (predecessor): https://github.com/gitleaks/gitleaks

## Checklist

- [X] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [X] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
