### PR TITLE
fix: Add Oxc tooling terms (oxlint, oxfmt) to software-terms dictionary

### DIFF
--- a/dictionaries/software-terms/dict/software-tools.txt
+++ b/dictionaries/software-terms/dict/software-tools.txt
@@ -205,6 +205,7 @@ OpenVPN
 OpenVZ
 Opsgenie
 Ouroboros
+Oxc
 Packagecloud
 Pentoo
 PerfView
@@ -478,6 +479,10 @@ openjdk
 openldap
 otelcol
 otlphttp
+oxfmt
+oxfmtrc
+oxlint
+oxlintrc
 parentbased
 pbcopy
 pbpaste

--- a/dictionaries/software-terms/src/software-tools.txt
+++ b/dictionaries/software-terms/src/software-tools.txt
@@ -395,6 +395,11 @@ OSMC
 otelcol
 otlphttp
 Ouroboros
+Oxc
+oxfmt
+oxfmtrc
+oxlint
+oxlintrc
 OXSecurity
 Packagecloud
 parentbased


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _software-terms_ (file `software-tools.txt`)

## Description

Add Oxc tooling identifiers to the `software-terms` dictionary so that command line binaries and configuration file names produced by the Oxidation Compiler (Oxc) toolchain are recognized by cspell.

New entries:

- `Oxc`: umbrella project name (the Oxidation Compiler).
- `oxlint`: Oxc JavaScript/TypeScript linter binary.
- `oxlintrc`: matches the `.oxlintrc.json` / `.oxlintrc.jsonc` configuration file names.
- `oxfmt`: Oxc formatter binary.
- `oxfmtrc`: matches the `.oxfmtrc.json` / `.oxfmtrc.jsonc` configuration file names.

This mirrors the existing convention already used in this dictionary for similar tools, e.g. `stylelint` + `stylelintrc`, `proselint` + `proselintrc`, `Secretlint` + `secretlintrc`.

## References

- Oxc: https://oxc.rs
- Oxlint config: https://oxc.rs/docs/guide/usage/linter/config.html
- Oxfmt config: https://oxc.rs/docs/guide/usage/formatter.html

## Checklist

- [X] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [X] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
