### PR TITLE
fix: Add idempotently to software-terms dictionary

### DIFF
--- a/dictionaries/software-terms/dict/softwareTerms.txt
+++ b/dictionaries/software-terms/dict/softwareTerms.txt
@@ -1401,6 +1401,7 @@ id
 idempotence
 idempotency
 idempotent
+idempotently
 ident
 identicon
 ideographic

--- a/dictionaries/software-terms/src/software-terms.txt
+++ b/dictionaries/software-terms/src/software-terms.txt
@@ -841,6 +841,7 @@ id
 idempotence
 idempotency
 idempotent
+idempotently
 ident
 identicon
 ideographic


### PR DESCRIPTION
# Add/Fix Dictionary

Dictionary: `software-terms`

## Description

The `software-terms` dictionary already contains `idempotence`, `idempotency`, and `idempotent`, but not the adverb form `idempotently`.

There is currently no exact dictionary hit for it — it is only accepted when compound-word splitting happens to parse it as `idem` + `potently`:

```text
cspell trace idempotently
idempotently  - softwareTerms
idem+potently * en_us
```

Configurations that do not allow that compound behavior report the legitimate word as unknown. `idempotently` is common in software documentation, for example: "the operation can be retried idempotently."

This adds `idempotently` to `src/software-terms.txt` directly after `idempotent`, and regenerates `dict/softwareTerms.txt` with `cspell-tools-cli build softwareTerms`. The result is two files, one added line each, with no other churn.

## References

- Closes #5586

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - adding a single word to an existing dictionary
