### PR TITLE
fix: Add 'subdeps' term to coding-terms

### DIFF
--- a/dictionaries/software-terms/src/coding-terms.txt
+++ b/dictionaries/software-terms/src/coding-terms.txt
@@ -966,3 +966,4 @@ zMax
 zMin
 zPos
 zVal
+subdeps # sub-dependencies

--- a/dictionaries/software-terms/src/coding-terms.txt
+++ b/dictionaries/software-terms/src/coding-terms.txt
@@ -749,6 +749,7 @@ stdWin
 strLen
 subdep # https://github.com/search?q=subdep&type=code
 subdeps # https://pnpm.io/settings#blockexoticsubdeps
+subdeps # sub-dependencies
 subdir
 subDirective
 subDirectives
@@ -966,4 +967,3 @@ zMax
 zMin
 zPos
 zVal
-subdeps # sub-dependencies


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _software terms_

## Description

- Add 'subdeps' term to coding-terms

## References

- Used in various tools to indicate sub-dependencies.

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
