### PR TITLE
fix: Add antizionism to shared English dictionary

### DIFF
--- a/dictionaries/en_shared/dict/shared-additional-words.txt
+++ b/dictionaries/en_shared/dict/shared-additional-words.txt
@@ -19,6 +19,7 @@ agentic
 amphitheatre
 antecessor
 antecessors
+anti-Zionism
 antizionism
 archivability
 archivable

--- a/dictionaries/en_shared/dict/shared-additional-words.txt
+++ b/dictionaries/en_shared/dict/shared-additional-words.txt
@@ -19,6 +19,7 @@ agentic
 amphitheatre
 antecessor
 antecessors
+antizionism
 archivability
 archivable
 archivables

--- a/dictionaries/en_shared/src/shared-additional-words.txt
+++ b/dictionaries/en_shared/src/shared-additional-words.txt
@@ -6,6 +6,7 @@ Alpha Centauri
 amphitheatre
 antecessor
 antecessors
+anti-Zionism
 antizionism
 archivability
 archivable

--- a/dictionaries/en_shared/src/shared-additional-words.txt
+++ b/dictionaries/en_shared/src/shared-additional-words.txt
@@ -6,6 +6,7 @@ Alpha Centauri
 amphitheatre
 antecessor
 antecessors
+antizionism
 archivability
 archivable
 archivables


### PR DESCRIPTION
Adds "antizionism" to the shared English word list.

- The Journal of Contemporary Antisemitism (Academic Studies Press) specifies "antizionism" in its author guidelines: https://static1.squarespace.com/static/5fd29a1f51ae5c1b3ea73a07/t/60df2ecb4875534daeca3c51/1625239247403/Instructions%2Bfor%2BJCA%2BAuthors.pdf
- Library of Congress Subject Headings lists "Antizionism" as a recognized variant of the "Anti-Zionism" heading: https://id.loc.gov/search/?q=antizionism
- A Government of Canada report (Canadian Heritage, Aug 2026) uses the unhyphenated spelling throughout: https://www.canada.ca/en/canadian-heritage/services/canada-holocaust/antisemitism/campus-antisemitism-student-experiences.html

cspell already accepts antisemitism (v10.1.0); similarly, the point here is simply to avoid flagging an attested unhyphenated form as a spelling error. Writers using antizionism currently get flagged with no suggestion. Happy to move it to a different list if you'd prefer.