### PR TITLE
chore: Add 'hunspell-reader' to minimumReleaseAgeExclude

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ minimumReleaseAgeExclude:
   - '@cspell/*'
   - 'cspell'
   - 'cspell-*'
+  - hunspell-reader
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
 trustPolicyExclude:


### PR DESCRIPTION

<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

This pull request makes a small update to the `pnpm-workspace.yaml` configuration by adding `hunspell-reader` to the `minimumReleaseAgeExclude` list. This means that the `hunspell-reader` package will be excluded from the minimum release age constraint.

`hunspell-reader` is used as part of `cspell-tools` to build the dictionaries.

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
