### PR TITLE
fix: Add support for Segmentation

### DIFF
--- a/dictionaries/th_th/cspell-ext.json
+++ b/dictionaries/th_th/cspell-ext.json
@@ -15,7 +15,8 @@
         {
             "languageId": "*",
             "locale": "th,th-th",
-            "dictionaries": ["th-th"]
+            "dictionaries": ["th-th"],
+            "useIntlWordSegmentation": true
         }
     ]
 }


### PR DESCRIPTION
<!---
name: Add to Dictionary
about: PR for adding (to) a dictionary
title: 'fix: '
labels: dictionary
--->

# Add/Fix Dictionary

Dictionary: _th-TH_

## Description

Segment documents into words when Thai is selected.

## References

```ts
    /**
     * Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.
     * The locale used for the segmentation is based on the {@link language} setting.
     *
     * @since 10.2.0
     */
    useIntlWordSegmentation?: boolean;
```
[`useIntlWordSegmentation`](https://github.com/streetsidesoftware/cspell/blob/736e9565002e829b7aad093fd0e62f27df4e518d/packages/cspell-types/src/CSpellSettingsDef.ts#L629-L635)

## Checklist

- [x] By submitting this pull-request, you agree to follow our [Code of Conduct](https://github.com/streetsidesoftware/cspell-dicts/blob/main/CODE_OF_CONDUCT.md)
- [x] Verify that the title starts with the correct prefix:
  - `fix:` - for minor changes like adding words or fixing spelling issues.
  - `feat:` - for a significant change like adding a whole new set of words to a dictionary.
  - `feat!:` - for breaking changes, like file format or licensing changes.
  - `chore:` - for changes that do not impact the content of dictionaries.
